### PR TITLE
fix: compressor has a conflict with the TypeScript feature that removes unused imports

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use oxc::span::SourceType;
 
-use crate::{Case, Driver};
+use crate::{driver::default_transformer_options, Case, Driver};
 
 pub struct CompressorRunner;
 
@@ -17,6 +17,12 @@ impl Case for CompressorRunner {
 
     fn driver(&self) -> Driver {
         // always compress js files
-        Driver { transform: true, compress: true, ..Driver::default() }
+        let mut transform = default_transformer_options();
+
+        // The compressor will remove unreachable code and the typescript plugin has a feature to remove unused imports.
+        // There is a conflict between these two features, so we need to disable the typescript plugin's feature.
+        transform.typescript.only_remove_type_imports = true;
+
+        Driver { transform: Some(transform), compress: true, ..Driver::default() }
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -14,13 +14,21 @@ use oxc::{
     CompilerInterface,
 };
 
+pub fn default_transformer_options() -> TransformOptions {
+    TransformOptions::from_preset_env(&EnvOptions {
+        targets: Targets::from_query("chrome 51"),
+        ..EnvOptions::default()
+    })
+    .unwrap()
+}
+
 use crate::Diagnostic;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
 pub struct Driver {
     // options
-    pub transform: bool,
+    pub transform: Option<TransformOptions>,
     pub compress: bool,
     pub mangle: bool,
     pub remove_whitespace: bool,
@@ -56,13 +64,7 @@ impl CompilerInterface for Driver {
     }
 
     fn transform_options(&self) -> Option<TransformOptions> {
-        self.transform.then(|| {
-            TransformOptions::from_preset_env(&EnvOptions {
-                targets: Targets::from_query("chrome 51"),
-                ..EnvOptions::default()
-            })
-            .unwrap()
-        })
+        self.transform.clone()
     }
 
     fn compress_options(&self) -> Option<CompressOptions> {

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use oxc::span::SourceType;
 
-use crate::{Case, Driver};
+use crate::{driver::default_transformer_options, Case, Driver};
 
 pub struct TransformerRunner;
 
@@ -18,6 +18,6 @@ impl Case for TransformerRunner {
     }
 
     fn driver(&self) -> Driver {
-        Driver { transform: true, ..Driver::default() }
+        Driver { transform: Some(default_transformer_options()), ..Driver::default() }
     }
 }


### PR DESCRIPTION
related: https://github.com/oxc-project/monitor-oxc/actions/runs/10630143033/job/29468505973

The compressor removes the unreachable codes but keeps the imports used in those codes, and then the typescript plugin removes the unused imports, creating a conflict.