### PR TITLE
Turns on Typescript's `only_remove_type_imports` option in transformer

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -17,12 +17,10 @@ impl Case for CompressorRunner {
 
     fn driver(&self) -> Driver {
         // always compress js files
-        let mut transform = default_transformer_options();
-
-        // The compressor will remove unreachable code and the typescript plugin has a feature to remove unused imports.
-        // There is a conflict between these two features, so we need to disable the typescript plugin's feature.
-        transform.typescript.only_remove_type_imports = true;
-
-        Driver { transform: Some(transform), compress: true, ..Driver::default() }
+        Driver {
+            transform: Some(default_transformer_options()),
+            compress: true,
+            ..Driver::default()
+        }
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -22,6 +22,8 @@ pub fn default_transformer_options() -> TransformOptions {
     .unwrap();
     // `object_rest_spread` is not ready
     options.es2018.object_rest_spread = None;
+    // Enables `only_remove_type_imports` avoiding removing all unused imports
+    options.typescript.only_remove_type_imports = true;
     options
 }
 


### PR DESCRIPTION
This option always causes idempotency test failures.