### PR TITLE
cargo: Set debug=false to avoid stack overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ ureq    = "3.0.0"
 pico-args = "0.5.0"
 project-root = "0.2.2"
 
+[profile.dev]
+# Disabling debug info reduces stack usage
+debug = false
+
 [profile.release]
 strip = false # "symbols" # Set to `false` for debug information
 debug = true # Set to `true` for debug information


### PR DESCRIPTION
The same as `oxc` main repo.

Stack overflow was occurred with https://www.npmjs.com/package/async?activeTab=code L7.