### PR TITLE
Add formatter detect_code_removal runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           - command: mangler
           - command: whitespace
           - command: formatter
+          - command: formatter_dcr
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d742b56656e8b14d63e7ea9806597b1849ae25412584c8adf78c0f67bd985e66"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,12 +245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,12 +259,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -301,11 +295,6 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -466,6 +455,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "json-escape-simd"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
+
+[[package]]
+name = "json-strip-comments"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4135b29c84322dbc3327272084360785665452213a576a991b3ac2f63148e82"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,12 +586,11 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
- "oxc_cfg",
  "oxc_codegen",
  "oxc_diagnostics",
  "oxc_isolated_declarations",
@@ -620,23 +623,24 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cfb121c9d3e0f9082856927f5cff9594279c91b544f4436e4bc971563caa60"
+checksum = "5c42cefdcbebec6b0b72229ac0e02261a6770cb7ba39ccc5475a856164066db1"
 dependencies = [
  "cfg-if",
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
  "thiserror",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6eabb57f935b454fbe0552ea0abaaf9eb0019b5fa05a7bbe7efd5bd8c765085"
+checksum = "05bbaa5b6b98826bb62b164406f703bee72c5287af9986f9c863fa8ea992b476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -644,8 +648,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc-schemars"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8b748122c8ec59a5f5f9cfff48c1e2f0c7a142a52f8bd24b40b10eb3e3bcfe"
+dependencies = [
+ "dyn-clone",
+ "oxc_schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "oxc_allocator"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -656,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -671,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -681,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -690,27 +706,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_cfg"
-version = "0.87.0"
-dependencies = [
- "bitflags",
- "itertools",
- "nonmax",
- "oxc_index",
- "oxc_syntax",
- "petgraph",
- "rustc-hash",
-]
-
-[[package]]
 name = "oxc_codegen"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "bitflags",
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
- "nonmax",
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
@@ -723,15 +725,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_compat"
+version = "0.95.0"
+dependencies = [
+ "cow-utils",
+ "oxc-browserslist",
+ "oxc_syntax",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "oxc_data_structures"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -740,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -753,31 +766,41 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.87.0"
+version = "0.95.0"
 
 [[package]]
 name = "oxc_formatter"
-version = "0.0.2"
+version = "0.9.0"
 dependencies = [
  "cow-utils",
+ "json-strip-comments",
+ "oxc-schemars",
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
+ "oxc_parser",
+ "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
  "rustc-hash",
+ "serde",
+ "serde_json",
  "unicode-width",
 ]
 
 [[package]]
 name = "oxc_index"
-version = "3.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa07b0cfa997730afed43705766ef27792873fdf5215b1391949fec678d2392"
+checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+dependencies = [
+ "nonmax",
+ "serde",
+]
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -792,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -801,19 +824,23 @@ dependencies = [
  "oxc_index",
  "oxc_semantic",
  "oxc_span",
+ "oxc_syntax",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_minifier"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_codegen",
+ "oxc_compat",
+ "oxc_data_structures",
  "oxc_ecmascript",
+ "oxc_index",
  "oxc_mangler",
  "oxc_parser",
  "oxc_regular_expression",
@@ -826,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -847,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -860,14 +887,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_schemars_derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1912e59b2446292fdbaf4f20d4a7b0fdbd2017f948ba6e3f8e8bfe3669bca35f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "oxc_semantic"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
- "oxc_cfg",
  "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
@@ -881,11 +919,12 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "4.1.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60410c89a9da2ce5b10946012b8a8605ecc41129cb7976bbfb73b85902071208"
+checksum = "0bd56ed0ec53da593c43d9ea65ced157fe319e454888eb65b239a275e3696499"
 dependencies = [
  "base64-simd",
+ "json-escape-simd",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -893,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -904,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -917,24 +956,22 @@ dependencies = [
  "oxc_index",
  "oxc_span",
  "phf",
- "rustc-hash",
  "unicode-id-start",
 ]
 
 [[package]]
 name = "oxc_transformer"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "base64",
  "compact_str",
- "cow-utils",
  "indexmap",
  "itoa",
  "memchr",
- "oxc-browserslist",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_compat",
  "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
@@ -952,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -972,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.87.0"
+version = "0.95.0"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -991,18 +1028,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
- "serde",
-]
 
 [[package]]
 name = "phf"
@@ -1220,6 +1245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1437,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ module_name_repetitions = "allow"
 
 [dependencies]
 oxc = { path = "../oxc/crates/oxc", features = ["full"] }
-oxc_formatter = { path = "../oxc/crates/oxc_formatter" }
+oxc_formatter = { path = "../oxc/crates/oxc_formatter", features = ["detect_code_removal"] }
 walkdir = "2.5.0"
 similar = "2.5.0"
 console = "0.16.0"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,8 +1,8 @@
 use oxc::{
     allocator::Allocator,
-    parser::{ParseOptions, Parser, ParserReturn},
+    parser::{Parser, ParserReturn},
 };
-use oxc_formatter::{FormatOptions, Formatter};
+use oxc_formatter::{FormatOptions, Formatter, get_parse_options};
 
 use crate::{Case, Diagnostic, Driver, NodeModulesRunner, Source};
 
@@ -25,12 +25,7 @@ impl Case for FormatterRunner {
         let Source { path, source_type, source_text } = source;
 
         let allocator = Allocator::new();
-        let options = ParseOptions {
-            preserve_parens: false,
-            allow_return_outside_function: true,
-            allow_v8_intrinsics: true,
-            parse_regular_expression: false,
-        };
+        let options = get_parse_options();
 
         let ParserReturn { program: program1, errors: errors1, .. } =
             Parser::new(&allocator, source_text, *source_type).with_options(options).parse();

--- a/src/formatter_dcr.rs
+++ b/src/formatter_dcr.rs
@@ -1,0 +1,49 @@
+use oxc::{
+    allocator::Allocator,
+    parser::{Parser, ParserReturn},
+};
+use oxc_formatter::{FormatOptions, Formatter, get_parse_options};
+
+use crate::{Case, Diagnostic, Driver, Source};
+
+// Another `FormatterRunner` for detecting code removal.
+//
+// Detection is enabled by the feature flag "detect_code_removal".
+// While the main FormatterRunner also has this capability,
+// there are currently many reported idempotency issues.
+// Therefore, for clarity, we separate this test to focus only on detecting code removal.
+
+pub struct FormatterDCRRunner;
+
+impl Case for FormatterDCRRunner {
+    fn name(&self) -> &'static str {
+        "Formatter(DetectCodeRemoval)"
+    }
+
+    fn enable_runtime_test(&self) -> bool {
+        false
+    }
+
+    fn driver(&self) -> Driver {
+        unreachable!()
+    }
+
+    fn test(&self, source: &Source) -> Result<(), Vec<Diagnostic>> {
+        let Source { source_type, source_text, .. } = source;
+
+        let allocator = Allocator::new();
+        let options = get_parse_options();
+
+        let ParserReturn { program, errors, .. } =
+            Parser::new(&allocator, source_text, *source_type).with_options(options).parse();
+        if !errors.is_empty() {
+            // Skip files that fail to parse, already reported in `FormatterRunner`
+            return Ok(());
+        }
+
+        // NOTE: This will panic if code removal is detected
+        let _ = Formatter::new(&allocator, FormatOptions::default()).format(&program);
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod codegen;
 pub mod compressor;
 pub mod dce;
 pub mod formatter;
+pub mod formatter_dcr;
 pub mod isolated_declarations;
 pub mod mangler;
 pub mod minifier;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,9 @@ use pico_args::Arguments;
 use monitor_oxc::{
     NodeModulesRunner, NodeModulesRunnerOptions, codegen::CodegenRunner,
     compressor::CompressorRunner, dce::DceRunner, formatter::FormatterRunner,
-    isolated_declarations, mangler::ManglerRunner, minifier::MinifierRunner,
-    remove_whitespace::RemoveWhitespaceRunner, transformer::TransformerRunner,
+    formatter_dcr::FormatterDCRRunner, isolated_declarations, mangler::ManglerRunner,
+    minifier::MinifierRunner, remove_whitespace::RemoveWhitespaceRunner,
+    transformer::TransformerRunner,
 };
 
 fn main() -> ExitCode {
@@ -61,6 +62,9 @@ fn main() -> ExitCode {
 
     if matches!(task, "formatter" | "default") {
         node_modules_runner.add_case(Box::new(FormatterRunner));
+    }
+    if matches!(task, "formatter_dcr" | "default") {
+        node_modules_runner.add_case(Box::new(FormatterDCRRunner));
     }
 
     let result = node_modules_runner.run_all();


### PR DESCRIPTION
The `detect_code_removal` feature is also enabled for the `FormatterRunner`, but I added a separate `FormatterDCRRunner` to make it easier to review the result.

The `FormatterRunner` already reports 95,000 lines of diff...