### PR TITLE
fix: avoid clobbering shipped JS files during transformer test

### DIFF
--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -17,7 +17,11 @@ impl Case for TransformerRunner {
         // Write js files for runtime test
         let new_extension = path.extension().unwrap().to_string_lossy().replace('t', "j");
         let new_path = path.with_extension(new_extension);
-        fs::write(new_path, source_text).unwrap();
+        // Some packages ship TS sources beside compiled JS. Do not clobber the
+        // shipped JS entry used by the runtime import test.
+        if &new_path == path || !new_path.exists() {
+            fs::write(new_path, source_text).unwrap();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Some packages ship TS sources beside compiled JS. The transformer test was unconditionally writing the transformed output to the `.js` path, clobbering the original shipped JS entry used by the runtime import test.
- Added a guard to skip writing when a JS counterpart already exists on disk.

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Run the monitor against a package that ships both `.ts` and `.js` files and confirm the shipped JS is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)