### PR TITLE
fix: update Rust toolchain to `1.95.0`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 profile = "default"


### PR DESCRIPTION
CI currenly fails:

https://github.com/oxc-project/monitor-oxc/actions/runs/25255149912/job/74053234988

```
error[E0658]: `if let` guards are experimental
   --> /home/runner/work/monitor-oxc/oxc/crates/oxc_transformer/src/typescript/class.rs:314:21
    |
314 | /                     if !prop.r#static
315 | |                         && !prop.declare
316 | |                         && let PropertyKey::StaticIdentifier(ident) = &prop.key =>
    | |_______________________________________________________________________________^
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
``` 

This PR bumps the rust toolchain to 1.95.0 so that it now builds against the current oxc main branch.

Note: i'm not sure how these changes to the transformer snuck in as our msrv should'e prevented it