### PR TITLE
chore: expect-fail broken upstream packages in smoke tests

### DIFF
--- a/generate.mjs
+++ b/generate.mjs
@@ -14,11 +14,31 @@ const expectedFailures = new Map([
     },
   ],
   [
-    "eslint-plugin-jest",
+    "minipass-flush",
     {
-      reason:
-        "Currently pulls @typescript-eslint/utils with an ESLint 10-incompatible FlatESLint import chain.",
-      message: "Class extends value undefined is not a constructor or null",
+      reason: "minipass-flush@2.0.0 was published with an empty tarball; the exports field points to a missing dist/.",
+      message: "minipass-flush/dist/esm/index.js",
+    },
+  ],
+  [
+    "minipass-pipeline",
+    {
+      reason: "minipass-pipeline@3.0.0 was published with an empty tarball; the exports field points to a missing dist/.",
+      message: "minipass-pipeline/dist/esm/index.js",
+    },
+  ],
+  [
+    "pure-rand",
+    {
+      reason: "pure-rand@8.x removed the `.` (main) entry from its exports map and only ships subpath imports.",
+      message: 'No "exports" main defined',
+    },
+  ],
+  [
+    "@ardatan/relay-compiler",
+    {
+      reason: "@ardatan/relay-compiler@13.0.1 has a broken internal require path (./util/nullthrowsOSS from lib/runner/).",
+      message: "Cannot find module './util/nullthrowsOSS'",
     },
   ],
 ]);

--- a/src/dynamic.test.mjs
+++ b/src/dynamic.test.mjs
@@ -11,7 +11,10 @@ test("@alloc/quick-lru", () => import("@alloc/quick-lru").then(assert.ok));
 test("@ampproject/remapping", () => import("@ampproject/remapping").then(assert.ok));
 test("@apideck/better-ajv-errors", () => import("@apideck/better-ajv-errors").then(assert.ok));
 test("@apidevtools/json-schema-ref-parser", () => import("@apidevtools/json-schema-ref-parser").then(assert.ok));
-test("@ardatan/relay-compiler", () => import("@ardatan/relay-compiler").then(assert.ok));
+// Expected failure @ardatan/relay-compiler: @ardatan/relay-compiler@13.0.1 has a broken internal require path (./util/nullthrowsOSS from lib/runner/).
+test("@ardatan/relay-compiler", async () => {
+  await assert.rejects(import("@ardatan/relay-compiler"), new RegExp("Cannot find module './util/nullthrowsOSS'"));
+});
 test("@asamuzakjp/css-color", () => import("@asamuzakjp/css-color").then(assert.ok));
 test("@asamuzakjp/dom-selector", () => import("@asamuzakjp/dom-selector").then(assert.ok));
 test("@aws-crypto/crc32", () => import("@aws-crypto/crc32").then(assert.ok));
@@ -1296,10 +1299,7 @@ test("eslint-import-resolver-node", () => import("eslint-import-resolver-node").
 test("eslint-import-resolver-typescript", () => import("eslint-import-resolver-typescript").then(assert.ok));
 test("eslint-plugin-es", () => import("eslint-plugin-es").then(assert.ok));
 test("eslint-plugin-flowtype", () => import("eslint-plugin-flowtype").then(assert.ok));
-// Expected failure eslint-plugin-jest: Currently pulls @typescript-eslint/utils with an ESLint 10-incompatible FlatESLint import chain.
-test("eslint-plugin-jest", async () => {
-  await assert.rejects(import("eslint-plugin-jest"), new RegExp("Class extends value undefined is not a constructor or null"));
-});
+test("eslint-plugin-jest", () => import("eslint-plugin-jest").then(assert.ok));
 test("eslint-plugin-jsx-a11y", () => import("eslint-plugin-jsx-a11y").then(assert.ok));
 test("eslint-plugin-n", () => import("eslint-plugin-n").then(assert.ok));
 test("eslint-plugin-prettier", () => import("eslint-plugin-prettier").then(assert.ok));
@@ -2006,8 +2006,14 @@ test("minimist-options", () => import("minimist-options").then(assert.ok));
 test("minipass", () => import("minipass").then(assert.ok));
 test("minipass-collect", () => import("minipass-collect").then(assert.ok));
 test("minipass-fetch", () => import("minipass-fetch").then(assert.ok));
-test("minipass-flush", () => import("minipass-flush").then(assert.ok));
-test("minipass-pipeline", () => import("minipass-pipeline").then(assert.ok));
+// Expected failure minipass-flush: minipass-flush@2.0.0 was published with an empty tarball; the exports field points to a missing dist/.
+test("minipass-flush", async () => {
+  await assert.rejects(import("minipass-flush"), new RegExp("minipass-flush/dist/esm/index.js"));
+});
+// Expected failure minipass-pipeline: minipass-pipeline@3.0.0 was published with an empty tarball; the exports field points to a missing dist/.
+test("minipass-pipeline", async () => {
+  await assert.rejects(import("minipass-pipeline"), new RegExp("minipass-pipeline/dist/esm/index.js"));
+});
 test("minipass-sized", () => import("minipass-sized").then(assert.ok));
 test("minizlib", () => import("minizlib").then(assert.ok));
 test("mississippi", () => import("mississippi").then(assert.ok));
@@ -2373,7 +2379,10 @@ test("punycode.js", () => import("punycode.js").then(assert.ok));
 test("pupa", () => import("pupa").then(assert.ok));
 test("puppeteer", () => import("puppeteer").then(assert.ok));
 test("puppeteer-core", () => import("puppeteer-core").then(assert.ok));
-test("pure-rand", () => import("pure-rand").then(assert.ok));
+// Expected failure pure-rand: pure-rand@8.x removed the `.` (main) entry from its exports map and only ships subpath imports.
+test("pure-rand", async () => {
+  await assert.rejects(import("pure-rand"), new RegExp("No \"exports\" main defined"));
+});
 test("pvtsutils", () => import("pvtsutils").then(assert.ok));
 test("q", () => import("q").then(assert.ok));
 test("qrcode", () => import("qrcode").then(assert.ok));

--- a/src/static.test.mjs
+++ b/src/static.test.mjs
@@ -22,8 +22,10 @@ import * as _9 from "@apideck/better-ajv-errors";
 test("@apideck/better-ajv-errors", () => assert.ok(_9));
 import * as _10 from "@apidevtools/json-schema-ref-parser";
 test("@apidevtools/json-schema-ref-parser", () => assert.ok(_10));
-import * as _11 from "@ardatan/relay-compiler";
-test("@ardatan/relay-compiler", () => assert.ok(_11));
+// Expected failure @ardatan/relay-compiler: @ardatan/relay-compiler@13.0.1 has a broken internal require path (./util/nullthrowsOSS from lib/runner/).
+test("@ardatan/relay-compiler", async () => {
+  await assert.rejects(import("@ardatan/relay-compiler"), new RegExp("Cannot find module './util/nullthrowsOSS'"));
+});
 import * as _12 from "@asamuzakjp/css-color";
 test("@asamuzakjp/css-color", () => assert.ok(_12));
 import * as _13 from "@asamuzakjp/dom-selector";
@@ -2592,10 +2594,8 @@ import * as _1294 from "eslint-plugin-es";
 test("eslint-plugin-es", () => assert.ok(_1294));
 import * as _1295 from "eslint-plugin-flowtype";
 test("eslint-plugin-flowtype", () => assert.ok(_1295));
-// Expected failure eslint-plugin-jest: Currently pulls @typescript-eslint/utils with an ESLint 10-incompatible FlatESLint import chain.
-test("eslint-plugin-jest", async () => {
-  await assert.rejects(import("eslint-plugin-jest"), new RegExp("Class extends value undefined is not a constructor or null"));
-});
+import * as _1296 from "eslint-plugin-jest";
+test("eslint-plugin-jest", () => assert.ok(_1296));
 import * as _1297 from "eslint-plugin-jsx-a11y";
 test("eslint-plugin-jsx-a11y", () => assert.ok(_1297));
 import * as _1298 from "eslint-plugin-n";
@@ -4004,10 +4004,14 @@ import * as _1998 from "minipass-collect";
 test("minipass-collect", () => assert.ok(_1998));
 import * as _1999 from "minipass-fetch";
 test("minipass-fetch", () => assert.ok(_1999));
-import * as _2000 from "minipass-flush";
-test("minipass-flush", () => assert.ok(_2000));
-import * as _2001 from "minipass-pipeline";
-test("minipass-pipeline", () => assert.ok(_2001));
+// Expected failure minipass-flush: minipass-flush@2.0.0 was published with an empty tarball; the exports field points to a missing dist/.
+test("minipass-flush", async () => {
+  await assert.rejects(import("minipass-flush"), new RegExp("minipass-flush/dist/esm/index.js"));
+});
+// Expected failure minipass-pipeline: minipass-pipeline@3.0.0 was published with an empty tarball; the exports field points to a missing dist/.
+test("minipass-pipeline", async () => {
+  await assert.rejects(import("minipass-pipeline"), new RegExp("minipass-pipeline/dist/esm/index.js"));
+});
 import * as _2002 from "minipass-sized";
 test("minipass-sized", () => assert.ok(_2002));
 import * as _2003 from "minizlib";
@@ -4738,8 +4742,10 @@ import * as _2365 from "puppeteer";
 test("puppeteer", () => assert.ok(_2365));
 import * as _2366 from "puppeteer-core";
 test("puppeteer-core", () => assert.ok(_2366));
-import * as _2367 from "pure-rand";
-test("pure-rand", () => assert.ok(_2367));
+// Expected failure pure-rand: pure-rand@8.x removed the `.` (main) entry from its exports map and only ships subpath imports.
+test("pure-rand", async () => {
+  await assert.rejects(import("pure-rand"), new RegExp("No \"exports\" main defined"));
+});
 import * as _2368 from "pvtsutils";
 test("pvtsutils", () => assert.ok(_2368));
 import * as _2369 from "q";


### PR DESCRIPTION
## Summary

- The codegen job (and several others) was failing with `ERR_MODULE_NOT_FOUND` on `node_modules/minipass-flush/dist/esm/index.js` — the static-import smoke test crashes on a broken upstream package before any test body runs.
- Four packages in the current dependency graph fail at static import time in the latest dist-tag. Document each one as an expected failure with the upstream error so we keep exercising them and notice if they get fixed.
- Also drops `eslint-plugin-jest` from `expectedFailures` since it now imports cleanly (the assertion was failing with `Missing expected rejection`).

## Broken upstream packages

| Package | Why |
|---|---|
| `minipass-flush@2.0.0` | Empty tarball; `exports` points to a missing `dist/`. |
| `minipass-pipeline@3.0.0` | Same — empty tarball, missing `dist/`. |
| `pure-rand@8.x` | Removed the `.` (main) entry from its exports map; only ships subpath imports. |
| `@ardatan/relay-compiler@13.0.1` | Broken internal `require` path (`./util/nullthrowsOSS` from `lib/runner/`). |

These were discovered in one pass by looping `await import(name)` over every entry in `static.test.mjs`. Static imports crash the file as a whole, so the original CI log only ever showed the first one (`minipass-flush`) — but all four were latent.

## Why expectedFailures instead of ignoreList

`expectedFailures` keeps the packages installed and exercised via `assert.rejects(import(name))`, so:
- We still verify they fail in the way we expect.
- The test surfaces it loudly (as it just did for `eslint-plugin-jest`) when upstream gets fixed.
- The diff is minimal — `staticIndex` doesn't shift, so only the affected entries change (~83 lines vs ~9000 from a full regen).

## Out of scope

The other failing jobs in [run 25664145532](https://github.com/oxc-project/monitor-oxc/actions/runs/25664145532) (`dce`, `formatter`, `formatter_dcr`) are unrelated — real oxc output bugs (dropped `/* @__PURE__ */`, comments re-injected mid-ternary, etc.) and need to be fixed in oxc.

## Test plan

- [x] `pnpm test` passes locally (3014/3014)
- [x] `node --check generate.mjs`, `node --check src/static.test.mjs`, `node --check src/dynamic.test.mjs`
- [ ] CI on this branch goes green for the previously-affected jobs (`codegen`, `transformer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)