### PR TITLE
chore: skip @typespec/ts-http-runtime sendRequest.js in compressor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,10 @@ const PATH_IGNORES: &[&str] = &[
     // TS(1015): A parameter cannot have a question mark and an initializer.
     "node_modules/react-redux/src/hooks/useDispatch.ts",
     "node_modules/react-redux/src/hooks/useStore.ts",
+    // compressor non-idempotent merge of adjacent ifs returning `{ body }`
+    "node_modules/@typespec/ts-http-runtime/dist/react-native/client/sendRequest.js",
+    "node_modules/@typespec/ts-http-runtime/dist/esm/client/sendRequest.js",
+    "node_modules/@typespec/ts-http-runtime/dist/browser/client/sendRequest.js",
 ];
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- Adds three dist variants of `@typespec/ts-http-runtime`'s `sendRequest.js` to `PATH_IGNORES` so the compressor smoke test stops failing.
- The compressor is non-idempotent on this file: pass 1 leaves the `typeof body == "function"` branch separate while merging the other three, and pass 2 then merges all four. That's a real oxc minifier bug to fix upstream — this just unblocks CI in the meantime.

## Example

Input (excerpt from `getRequestBody`, dist/{react-native,esm,browser}/client/sendRequest.js):
```js
if (typeof FormData !== "undefined" && body instanceof FormData) return { body };
if (isBlob(body)) return { body };
if (isReadableStream(body)) return { body };
if (typeof body === "function") return { body: body };
```

Pass 1 output:
```js
if (typeof FormData < "u" && body instanceof FormData || isBlob(body) || isReadableStream(body)) return { body };
if (typeof body == "function") return { body };
```

Pass 2 output (differs from pass 1, so idempotency_test fails):
```js
if (typeof FormData < "u" && body instanceof FormData || isBlob(body) || isReadableStream(body) || typeof body == "function") return { body };
```

## Test plan

- Confirmed the three failing paths from run 25841541741 / job 75927903765 match the new `PATH_IGNORES` substring entries (paths under `node_modules/.pnpm/@typespec+ts-http-runtime@*/node_modules/@typespec/ts-http-runtime/dist/{react-native,esm,browser}/client/sendRequest.js`).
- Local `cargo build` not exercised — the change is three string literals added to a `const &[&str]` array; CI compiles it.