### PR TITLE
fix(driver): use CompressOptions::dce() for the dce runner

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -128,7 +128,7 @@ impl Driver {
         let allocator = Allocator::default();
         let mut ret = Parser::new(&allocator, source_text, source_type).parse();
         let program = &mut ret.program;
-        Compressor::new(&allocator).dead_code_elimination(program, CompressOptions::default());
+        Compressor::new(&allocator).dead_code_elimination(program, CompressOptions::dce());
         Codegen::new().build(program).code
     }
 }


### PR DESCRIPTION
## Summary

`Driver::dce` was calling `Compressor::dead_code_elimination` with `CompressOptions::default()`. That default is `CompressOptions::smallest()` — full minify, including `sequences: true` and `join_vars: true` — not DCE. So the "dce" runner has been a full-minify runner for a while; `oxc_minifier --example dce` uses `CompressOptions::dce()` (no sequences/join-vars) for the same job.

Two consequences of the misalignment:

- The `if (...) { throw X; }` → `if (...) throw X` and `new Error(...)` ternary rewrites shift comment ownership across the inserted parens, so the runner's idempotency check (one pass vs two) trips on roughly 650 files where the second pass repositions the comments differently from the first. See the `micromark-core-commonmark` / `jest-each` / `aws-sdk` failures in run [26082752217](https://github.com/oxc-project/monitor-oxc/actions/runs/26082752217/job/76688477774).
- The `dce` label is misleading; the mangler/compressor runners already cover full-minify behaviour.

Switching to `CompressOptions::dce()` clears those ~650 failures without losing DCE coverage. Verified locally on the full 116,429-file corpus: 759 → 9 idempotency failures, the remaining 9 being two distinct upstream oxc bugs (`/* @__PURE__ */` not re-evaluated after peephole inlining, and arrow-alternate comment-attachment loss) that need separate fixes.