### PR TITLE
ci: edit placeholder comment with run URL on start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,34 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
+  start:
+    if: ${{ inputs.issue-number && inputs.comment-id }}
+    name: Update Comment with Run URL
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: oxc-project
+          repositories: |
+            ${{ github.event.repository.name }}
+            oxc
+
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: oxc-project/oxc
+          issue-number: ${{ inputs.issue-number }}
+          comment-id: ${{ inputs.comment-id }}
+          edit-mode: replace
+          body: |
+            ## [Monitor Oxc](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            Running…
+
   build:
     name: Build
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

When `ci.yml` is dispatched from `oxc-project/oxc` (the label-triggered `monitor-oxc.yml` and the release-prep `prepare_release_crates.yml`), the dispatcher posts a placeholder comment but can only link the generic workflow page — the dispatch API doesn't return a run ID, so the dispatcher has no way to point at the specific run.

This adds a `start` job that runs in parallel with `build` (no `needs:`) and edits the placeholder via `peter-evans/create-or-update-comment` with a link to `actions/runs/${{ github.run_id }}`. We know the URL because we *are* the run.

## Behavior

- Gated by `${{ inputs.issue-number && inputs.comment-id }}` — same gate as the `comment` job's edit step. Scheduled, push, and unrelated PR runs are unaffected.
- Runs in parallel with `build`, so the link appears within seconds of the dispatcher firing — no polling, no race.
- The body is replaced again with the per-suite result table when the `comment` job runs at the end. So the lifecycle is: placeholder → "Running…" with run URL → result table.
- Reuses the same App-token mint pattern (`repositories:` includes `${{ github.event.repository.name }}` and `oxc`) as the existing `comment` job.

## Companion change

Paired with https://github.com/oxc-project/oxc/pull/22712, which adds the label-triggered dispatcher that produces the initial placeholder.
