### PR TITLE
feat: include monitored commit in CI status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,19 @@ jobs:
             const commentId = Number(process.env.COMMENT_ID);
             const oxcRef = process.env.OXC_REF || 'main';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const { data: commit } = await github.rest.repos.getCommit({
-              owner: 'oxc-project',
-              repo: 'oxc',
-              ref: oxcRef,
-            });
-            const commitUrl = `${context.serverUrl}/oxc-project/oxc/commit/${commit.sha}`;
-            const shortSha = commit.sha.slice(0, 12);
+            let commitUrl = `${context.serverUrl}/oxc-project/oxc/tree/${oxcRef}`;
+            let shortSha = oxcRef;
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: 'oxc-project',
+                repo: 'oxc',
+                ref: oxcRef,
+              });
+              commitUrl = `${context.serverUrl}/oxc-project/oxc/commit/${commit.sha}`;
+              shortSha = commit.sha.slice(0, 12);
+            } catch (error) {
+              console.warn(`Failed to resolve oxc ref "${oxcRef}": ${String(error)}`);
+            }
 
             const emojiFor = (state) => ({
               success: ':white_check_mark:',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,20 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ inputs.comment-id }}
+          OXC_REF: ${{ inputs.ref || 'main' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const commentId = Number(process.env.COMMENT_ID);
+            const oxcRef = process.env.OXC_REF || 'main';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: 'oxc-project',
+              repo: 'oxc',
+              ref: oxcRef,
+            });
+            const commitUrl = `${context.serverUrl}/oxc-project/oxc/commit/${commit.sha}`;
+            const shortSha = commit.sha.slice(0, 12);
 
             const emojiFor = (state) => ({
               success: ':white_check_mark:',
@@ -75,7 +84,7 @@ jobs:
                 const suite = j.name.replace(/^Test /, '');
                 return `| [${suite}](${j.html_url}) | ${emojiFor(state)} |`;
               }).join('\n');
-              return `## [Monitor Oxc](${runUrl})\n\n| suite | result |\n|-------|--------|\n${rows}`;
+              return `## [Monitor Oxc](${runUrl})\n\nCommit: [\`${shortSha}\`](${commitUrl})\n\n| suite | result |\n|-------|--------|\n${rows}`;
             };
 
             for (let i = 0; i < 60; i++) {


### PR DESCRIPTION
## Summary

- Resolve the monitored `oxc-project/oxc` ref in the status job.
- Include a linked short commit SHA in the Monitor Oxc status comment before the suite table.

## Why

When CI is dispatched with a branch or other ref, the status comment did not show the exact Oxc commit being tested. Showing the resolved commit makes the reported results easier to audit.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`