### PR TITLE
fix(formatter): skip Flow files instead of reporting parse failures

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -39,6 +39,12 @@ impl Case for FormatterRunner {
         ) {
             Ok(formatted) => formatted.print().unwrap().into_code(),
             Err(error) => {
+                // oxc does not support Flow syntax, so Flow files can't be
+                // formatted. Skip them instead of reporting a failure (the
+                // transformer driver filters the same diagnostic).
+                if error.message.starts_with("Flow is not supported") {
+                    return Ok(source_text.to_string());
+                }
                 return Err(vec![Diagnostic {
                     case: self.name(),
                     path: path.clone(),


### PR DESCRIPTION
## Summary

- oxc doesn't support Flow syntax, so `oxc_formatter::format` returns a `Flow is not supported` parse error on Flow files (e.g. `eslint-plugin-jsx-a11y/__mocks__/JSXTextMock.js`). The formatter idempotency test reported these as failures, even though they aren't formatter bugs.
- Skip files whose original source fails to parse with that diagnostic — mirroring the transformer driver, which already filters the same `Flow is not supported` error. Other parse errors still fail, so genuine bugs aren't swallowed.
- Verified by running `./monitor-oxc formatter` over `eslint-plugin-jsx-a11y@6.10.2` (184 files including the Flow mock): `Ran 184 times.` with 0 failures (previously 1).
