### PR TITLE
ci: checkout oxc in the security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,4 +21,15 @@ jobs:
     name: Security Analysis
     runs-on: ubuntu-latest
     steps:
+      # The action runs `cargo metadata` when Cargo.lock changed, which needs
+      # the `oxc` path dependency (`../oxc`) to exist — same as the Build job.
+      - name: Checkout oxc
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: oxc-project/oxc
+          path: oxc
+
+      - run: mv oxc ../oxc
+
       - uses: oxc-project/security-action@781317603d045c3eafc99daef653fcac77e12aa8 # v1.0.3


### PR DESCRIPTION
## Summary

- The security action runs `cargo metadata` when `Cargo.lock` changed in the PR, which fails with `failed to read /home/runner/work/monitor-oxc/oxc/crates/oxc/Cargo.toml` — the `oxc` path dependency (`../oxc`) was never checked out. The workflow (added in #155) postdates the last Cargo.lock-touching PR, so the gap only surfaced now with #179.
- Mirror the Build job's oxc checkout before running the action. The action's internal monitor-oxc checkout is unaffected since `../oxc` sits outside the workspace directory.
- Verified by #179 (stacked on this): its security run exercises the cargo path against a real Cargo.lock change.