### PR TITLE
ci: self-review follow-ups for the guard and SHA plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,12 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     outputs:
-      oxc-sha: ${{ steps.oxc.outputs.sha }}
+      oxc-sha: ${{ steps.oxc.outputs.commit }}
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - name: Checkout oxc (${{ inputs.ref }})
+        id: oxc
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -169,10 +170,6 @@ jobs:
 
       - run: mv oxc ../oxc
 
-      - name: Get oxc commit
-        id: oxc
-        run: echo "sha=$(git -C ../oxc rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       # Reuse the binary when neither oxc nor our sources changed (common for
       # the 3-hourly scheduled runs), skipping the ~2 minute build.
       - name: Restore binary cache
@@ -180,7 +177,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ./target/release/monitor-oxc
-          key: binary-${{ runner.os }}-${{ steps.oxc.outputs.sha }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**') }}
+          key: binary-${{ runner.os }}-${{ steps.oxc.outputs.commit }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**') }}
 
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         if: steps.binary-cache.outputs.cache-hit != 'true'
@@ -200,7 +197,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ./target/release/monitor-oxc
-          key: binary-${{ runner.os }}-${{ steps.oxc.outputs.sha }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**') }}
+          key: binary-${{ runner.os }}-${{ steps.oxc.outputs.commit }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'src/**') }}
 
       - name: Upload Binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -279,6 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout oxc (${{ inputs.ref }})
+        id: oxc
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -305,10 +303,6 @@ jobs:
           path: tasks/coverage/test262
           ref: ${{ steps.test262.outputs.sha }}
 
-      - name: Get oxc commit
-        id: oxc
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       # Reuse the compiled coverage runner when oxc is unchanged, skipping the
       # ~2 minute build. The binary locates the repo from the working directory
       # (project-root crate), so on a hit it runs without cargo.
@@ -317,7 +311,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target/coverage/oxc_coverage
-          key: oxc-coverage-${{ runner.os }}-${{ steps.oxc.outputs.sha }}
+          key: oxc-coverage-${{ runner.os }}-${{ steps.oxc.outputs.commit }}
 
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         if: steps.coverage-cache.outputs.cache-hit != 'true'
@@ -338,7 +332,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target/coverage/oxc_coverage
-          key: oxc-coverage-${{ runner.os }}-${{ steps.oxc.outputs.sha }}
+          key: oxc-coverage-${{ runner.os }}-${{ steps.oxc.outputs.commit }}
 
       - run: ./target/coverage/oxc_coverage runtime
         if: steps.coverage-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,11 @@ jobs:
     outputs:
       unchanged: ${{ steps.marker.outputs.cache-hit }}
     steps:
-      - name: Resolve oxc main commit
-        id: oxc
-        run: echo "sha=$(gh api repos/oxc-project/oxc/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
+      - name: Resolve oxc and vuejs/core main commits
+        id: heads
+        run: |
+          echo "oxc=$(gh api repos/oxc-project/oxc/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
+          echo "vue=$(gh api repos/vuejs/core/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -145,7 +147,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .green-marker
-          key: green-${{ github.sha }}-${{ steps.oxc.outputs.sha }}
+          key: green-${{ github.sha }}-${{ steps.heads.outputs.oxc }}-${{ steps.heads.outputs.vue }}
           lookup-only: true
 
   build:
@@ -249,8 +251,12 @@ jobs:
     # See `test` — break the transitive skip from the guard.
     if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
+    outputs:
+      vue-sha: ${{ steps.vue.outputs.commit }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout vuejs/core
+        id: vue
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           repository: vuejs/core
@@ -274,6 +280,8 @@ jobs:
     if: ${{ !cancelled() && needs.guard.outputs.unchanged != 'true' }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    outputs:
+      oxc-sha: ${{ steps.oxc.outputs.commit }}
     steps:
       - name: Checkout oxc (${{ inputs.ref }})
         id: oxc
@@ -347,12 +355,15 @@ jobs:
   record:
     name: Record green run
     needs: [build, test, isolated_declarations, test262]
+    # success() = every needed job succeeded (false if any failed OR was
+    # skipped on the guard-hit path). The oxc SHA agreement check guards the
+    # race where oxc main advances between Build's and Test262's independent
+    # checkouts — recording then would certify a commit Test262 never tested;
+    # skipping the record just means one extra run.
     if: >-
       github.event_name == 'schedule' &&
-      needs.build.result == 'success' &&
-      needs.test.result == 'success' &&
-      needs.isolated_declarations.result == 'success' &&
-      needs.test262.result == 'success'
+      success() &&
+      needs.build.outputs.oxc-sha == needs.test262.outputs.oxc-sha
     runs-on: ubuntu-latest
     steps:
       - run: touch .green-marker
@@ -360,4 +371,4 @@ jobs:
       - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .green-marker
-          key: green-${{ github.sha }}-${{ needs.build.outputs.oxc-sha }}
+          key: green-${{ github.sha }}-${{ needs.build.outputs.oxc-sha }}-${{ needs.isolated_declarations.outputs.vue-sha }}


### PR DESCRIPTION
## Summary

Two verified findings from the stack's self-review:

- **Green-run marker now covers all tested inputs.** The key omitted `vuejs/core@main` (tested by isolated_declarations but free to move while the guard skips runs), and Build/Test262 check out oxc independently, so a mid-run main advance could record a commit Test262 never tested. The vue SHA joins the key, `record` only fires when the two oxc SHAs agree (disagreement just costs one extra run), and `success()` replaces the enumerated needs results so extending `needs` can't silently weaken the all-green requirement.
- **`actions/checkout`'s `commit` output replaces the two hand-rolled `git rev-parse` steps** (available since checkout v4.2.0), which also removes the Build variant's silent dependency on `mv oxc ../oxc` step ordering.

Stacked on #179.