### PR TITLE
chore: simplify notes plumbing to Option&lt;String&gt;

### DIFF
--- a/src/case.rs
+++ b/src/case.rs
@@ -15,27 +15,30 @@ pub trait Case: RefUnwindSafe + Sync {
         true
     }
 
-    /// Run the test for a single file. On success, returns any notes to be
-    /// printed by the runner (in deterministic file order); on failure, returns
-    /// diagnostics. Notes are returned rather than printed directly so that
-    /// parallel execution stays deterministic.
-    fn test(&self, source: &Source) -> Result<Vec<String>, Vec<Diagnostic>> {
+    /// Run the test for a single file. On success, returns an optional note to
+    /// be printed by the runner (in deterministic file order); on failure,
+    /// returns diagnostics. The note is returned rather than printed directly so
+    /// that parallel execution stays deterministic.
+    fn test(&self, source: &Source) -> Result<Option<String>, Vec<Diagnostic>> {
         if self.run_test(source) {
-            let (source_text, notes) = self.idempotency_test(source)?;
+            let (source_text, note) = self.idempotency_test(source)?;
             // Write js files for runtime test
             if source.source_type.is_javascript() {
                 fs::write(&source.path, source_text).unwrap();
             }
-            Ok(notes)
+            Ok(note)
         } else {
-            Ok(Vec::new())
+            Ok(None)
         }
     }
 
     fn driver(&self) -> Driver;
 
-    /// Returns the idempotent output text together with any notes to print.
-    fn idempotency_test(&self, source: &Source) -> Result<(String, Vec<String>), Vec<Diagnostic>> {
+    /// Returns the idempotent output text together with an optional note to print.
+    fn idempotency_test(
+        &self,
+        source: &Source,
+    ) -> Result<(String, Option<String>), Vec<Diagnostic>> {
         let Source { path, source_type, source_text } = source;
         let source_text2 = self.driver().run(path, source_text, *source_type)?;
         let source_text3 = self.driver().run(path, &source_text2, *source_type)?;
@@ -46,6 +49,6 @@ pub trait Case: RefUnwindSafe + Sync {
                 message: NodeModulesRunner::get_diff(&source_text2, &source_text3, false),
             }]);
         }
-        Ok((source_text3, Vec::new()))
+        Ok((source_text3, None))
     }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -25,7 +25,10 @@ impl Case for FormatterRunner {
         unreachable!()
     }
 
-    fn idempotency_test(&self, source: &Source) -> Result<(String, Vec<String>), Vec<Diagnostic>> {
+    fn idempotency_test(
+        &self,
+        source: &Source,
+    ) -> Result<(String, Option<String>), Vec<Diagnostic>> {
         let Source { path, source_type, source_text } = source;
 
         let allocator = Allocator::new();
@@ -43,7 +46,7 @@ impl Case for FormatterRunner {
                 // formatted. Skip them instead of reporting a failure (the
                 // transformer driver filters the same diagnostic).
                 if error.message.starts_with("Flow is not supported") {
-                    return Ok((source_text.clone(), Vec::new()));
+                    return Ok((source_text.clone(), None));
                 }
                 return Err(vec![Diagnostic {
                     case: self.name(),
@@ -79,7 +82,7 @@ impl Case for FormatterRunner {
                     // Return the note instead of printing it here, so the runner can
                     // emit it in deterministic order after the parallel phase.
                     let note = format!("{}\n{}\n{message}\n", self.name(), path.to_string_lossy());
-                    Ok((source_text3, vec![note]))
+                    Ok((source_text3, Some(note)))
                 }
                 // oxfmt diverges from Prettier (or Prettier could not classify it): fail.
                 Verdict::Mismatch(message) => {
@@ -88,7 +91,7 @@ impl Case for FormatterRunner {
             };
         }
 
-        Ok((source_text3, Vec::new()))
+        Ok((source_text3, None))
     }
 }
 

--- a/src/formatter_dcr.rs
+++ b/src/formatter_dcr.rs
@@ -25,7 +25,7 @@ impl Case for FormatterDCRRunner {
         unreachable!()
     }
 
-    fn test(&self, source: &Source) -> Result<Vec<String>, Vec<Diagnostic>> {
+    fn test(&self, source: &Source) -> Result<Option<String>, Vec<Diagnostic>> {
         let Source { path, source_type, source_text, .. } = source;
 
         let allocator = Allocator::new();
@@ -39,7 +39,7 @@ impl Case for FormatterDCRRunner {
         ) {
             Ok(formatted) => formatted.print().unwrap().into_code(),
             // Skip files that fail to parse, already reported in `FormatterRunner`
-            Err(_) => return Ok(Vec::new()),
+            Err(_) => return Ok(None),
         };
 
         if let Some(diff) = detect_code_removal(source_text, &source_text2, *source_type) {
@@ -50,6 +50,6 @@ impl Case for FormatterDCRRunner {
             }]);
         }
 
-        Ok(Vec::new())
+        Ok(None)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,19 +114,16 @@ impl NodeModulesRunner {
                     return None;
                 }
                 let source_type = SourceType::from_path(path).ok()?;
-                if PATH_IGNORES
-                    .iter()
-                    .any(|p| path.to_string_lossy().replace('\\', "/").contains(p))
-                {
+                let path_str = path.to_string_lossy().replace('\\', "/");
+                if PATH_IGNORES.iter().any(|p| path_str.contains(p)) {
                     return None;
                 }
                 if source_type.is_typescript_definition() {
                     return None;
                 }
                 if let Some(filter) = options.filter.as_ref() {
-                    let path = path.to_string_lossy();
-                    if path.contains(filter) {
-                        println!("Filtered {path}");
+                    if path_str.contains(filter) {
+                        println!("Filtered {path_str}");
                     } else {
                         return None;
                     }
@@ -182,10 +179,8 @@ impl NodeModulesRunner {
         // printed these inline during the loop; since nothing else is printed there,
         // emitting them here (in input order) reproduces that output exactly.
         for result in &results {
-            if let Ok(Ok(notes)) = result {
-                for note in notes {
-                    println!("{note}");
-                }
+            if let Ok(Ok(Some(note))) = result {
+                println!("{note}");
             }
         }
         println!("Ran {} times.", results.len());
@@ -194,7 +189,7 @@ impl NodeModulesRunner {
             .filter_map(|result| match result {
                 Err(panic_diagnostics) => Some(panic_diagnostics),
                 Ok(Err(test_diagnostics)) => Some(test_diagnostics),
-                Ok(Ok(_notes)) => None,
+                Ok(Ok(_note)) => None,
             })
             .flatten()
             .collect::<Vec<_>>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,7 @@ fn main() -> ExitCode {
     // Rayon workers default to 2 MiB stacks, which deeply nested expressions
     // in node_modules overflow (an abort, not a catchable panic). Match the
     // main thread's 8 MiB, as oxc's coverage runner does.
-    rayon::ThreadPoolBuilder::new()
-        .stack_size(8 * 1024 * 1024)
-        .build_global()
-        .unwrap();
+    rayon::ThreadPoolBuilder::new().stack_size(8 * 1024 * 1024).build_global().unwrap();
 
     let mut args = Arguments::from_env();
 

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -11,9 +11,9 @@ impl Case for TransformerRunner {
         "Transformer"
     }
 
-    fn test(&self, source: &Source) -> Result<Vec<String>, Vec<Diagnostic>> {
+    fn test(&self, source: &Source) -> Result<Option<String>, Vec<Diagnostic>> {
         let path = &source.path;
-        let (source_text, notes) = self.idempotency_test(source)?;
+        let (source_text, note) = self.idempotency_test(source)?;
         // Write js files for runtime test
         let new_extension = path.extension().unwrap().to_string_lossy().replace('t', "j");
         let new_path = path.with_extension(new_extension);
@@ -22,7 +22,7 @@ impl Case for TransformerRunner {
         if &new_path == path || !new_path.exists() {
             fs::write(new_path, source_text).unwrap();
         }
-        Ok(notes)
+        Ok(note)
     }
 
     fn driver(&self) -> Driver {


### PR DESCRIPTION
## Summary

- Self-review cleanup on #179's determinism refactor: only the formatter's `[Prettier: MATCHED]` warning ever produces a note, and at most one per file — `Option<String>` encodes that instead of `Vec` boilerplate at every return site. Console output unchanged.
- Also hoists the per-pattern `to_string_lossy().replace()` allocation in the node_modules walk (pre-existing; reused for the `--filter` check).

Stacked on #183.