### PR TITLE
feat: reserve exports/module names in the mangler runtime test

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -79,7 +79,13 @@ impl CompilerInterface for Driver {
     }
 
     fn mangle_options(&self) -> Option<MangleOptions> {
-        self.mangle.then(MangleOptions::default)
+        self.mangle.then(|| MangleOptions {
+            // Keep `exports` / `module` wrapper bindings so Node's cjs-module-lexer
+            // still detects named exports of mangled CommonJS / UMD packages
+            // (`import { queue } from "async"`). See oxc-project/oxc#24041.
+            reserved: ["exports", "module"].into_iter().map(Into::into).collect(),
+            ..MangleOptions::default()
+        })
     }
 
     fn codegen_options(&self) -> Option<CodegenOptions> {


### PR DESCRIPTION
Node's cjs-module-lexer detects a CommonJS module's named exports by lexically scanning for `exports.<name> =` / `module.exports` token patterns — no scope analysis. UMD / CommonJS wrappers bind `exports` / `module` as ordinary function parameters, and mangling renames them, erasing every named export the lexer can see: `import { queue } from "async"` fails the mangler runtime test ([failing run](https://github.com/oxc-project/monitor-oxc/actions/runs/28569108563/job/84702922472)).

Renaming these is ecosystem-standard (esbuild / terser / swc all do it by default), so oxc keeps its default behavior and instead provides `MangleOptions::reserved` — the terser `mangle.reserved` equivalent, added in oxc-project/oxc#24041. This suite imports prebuilt dists directly, so pass `["exports", "module"]`.

Depends on oxc-project/oxc#24041 (merged). The mangler job also needs oxc-project/oxc#24033 to pass its idempotency phase.