### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,6 @@
+style_edition = "2024"
 use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
