### PR TITLE
feat: run pinned repo test suites against minified sources

### DIFF
--- a/.github/workflows/bump-runtime-repos.yml
+++ b/.github/workflows/bump-runtime-repos.yml
@@ -1,0 +1,158 @@
+name: Bump Runtime Repos
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC.
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.repos.outputs.matrix }}
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - id: repos
+        run: echo "matrix=$(jq -c 'map({name, repo, sha})' runtime-repos.json)" >> "$GITHUB_OUTPUT"
+
+  check:
+    name: Check ${{ matrix.name }}
+    needs: setup
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - name: Resolve HEAD of ${{ matrix.repo }}
+        id: head
+        # Fail loudly on a bad resolve — an empty sha would skip the
+        # unchanged-check, silently check out the default branch, and could
+        # end up written into runtime-repos.json by the bump job.
+        run: |
+          sha=$(gh api "repos/${{ matrix.repo }}/commits/HEAD" --jq .sha)
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Skip if unchanged
+        id: skip
+        run: echo "unchanged=${{ steps.head.outputs.sha == matrix.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout ${{ matrix.repo }}
+        if: steps.skip.outputs.unchanged != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: ${{ matrix.repo }}
+          ref: ${{ steps.head.outputs.sha }}
+          path: target-repo
+
+      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
+        if: steps.skip.outputs.unchanged != 'true'
+
+      - run: corepack enable
+        if: steps.skip.outputs.unchanged != 'true'
+
+      - name: Baseline at HEAD
+        if: steps.skip.outputs.unchanged != 'true'
+        run: |
+          mkdir -p results
+          if node scripts/runtime-test.mjs install "${{ matrix.name }}" target-repo \
+            && node scripts/runtime-test.mjs baseline "${{ matrix.name }}" target-repo; then
+            status=green
+          else
+            status=red
+          fi
+          jq -n --arg name "${{ matrix.name }}" --arg sha "${{ steps.head.outputs.sha }}" \
+            --arg status "$status" '{name: $name, sha: $sha, status: $status}' \
+            > "results/${{ matrix.name }}.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.skip.outputs.unchanged != 'true'
+        with:
+          if-no-files-found: error
+          name: bump-${{ matrix.name }}
+          path: results/
+
+  bump:
+    name: Open bump PR
+    needs: check
+    # Run when check actually executed — including partial leg failures (their
+    # repos simply aren't bumped) — but not when it was skipped or cancelled,
+    # so an upstream failure can't masquerade as a quiet "no bumps" week.
+    if: ${{ !cancelled() && contains(fromJSON('["success", "failure"]'), needs.check.result) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: oxc-project
+          repositories: ${{ github.event.repository.name }}
+
+      # No persisted credentials (zizmor: artipacked); the push below
+      # authenticates explicitly with the app token instead.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bump-*
+          merge-multiple: true
+          path: results
+
+      - name: Apply green bumps and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          shopt -s nullglob
+          bumped=()
+          failed=()
+          for f in results/*.json; do
+            name=$(jq -r .name "$f")
+            sha=$(jq -r .sha "$f")
+            status=$(jq -r .status "$f")
+            old=$(jq -r --arg n "$name" '.[] | select(.name == $n) | .sha' runtime-repos.json)
+            if [ "$status" = green ]; then
+              jq --arg n "$name" --arg s "$sha" \
+                '(.[] | select(.name == $n) | .sha) = $s' runtime-repos.json > tmp.json
+              mv tmp.json runtime-repos.json
+              bumped+=("- \`$name\`: ${old:0:12} -> ${sha:0:12}")
+            else
+              failed+=("- \`$name\`: HEAD ${sha:0:12} baseline failed; keeping ${old:0:12}")
+            fi
+          done
+          if [ "${#bumped[@]}" -eq 0 ]; then
+            echo "No green bumps this week."
+            exit 0
+          fi
+          branch="bump-runtime-repos-${{ github.run_id }}-${{ github.run_attempt }}"
+          git config user.name "oxc-project[bot]"
+          git config user.email "oxc-project[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add runtime-repos.json
+          git commit -m "chore: bump runtime repo pins"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$branch"
+          {
+            printf 'Weekly runtime repo pin bump. CI on this PR runs the minified suites against the new pins.\n\n## Bumped\n'
+            printf '%s\n' "${bumped[@]}"
+            if [ "${#failed[@]}" -gt 0 ]; then
+              printf '\n## Baseline failed at HEAD (kept old pin)\n'
+              printf '%s\n' "${failed[@]}"
+            fi
+          } > body.md
+          gh pr create --title "chore: bump runtime repo pins" --body-file body.md --head "$branch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,67 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
 
+  runtime-setup:
+    name: Runtime Setup
+    needs: build
+    # See `test` — break the transitive skip from the guard.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.repos.outputs.matrix }}
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - id: repos
+        run: echo "matrix=$(jq -c 'map({name, repo, sha})' runtime-repos.json)" >> "$GITHUB_OUTPUT"
+
+  runtime:
+    name: Test Runtime (${{ matrix.name }})
+    needs: [build, runtime-setup]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.runtime-setup.result == 'success' }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.runtime-setup.outputs.matrix) }}
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: monitor-oxc
+
+      - run: chmod +x ./monitor-oxc
+
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: ${{ matrix.repo }}
+          ref: ${{ matrix.sha }}
+          path: target-repo
+
+      # No oxc-project/setup-node here: it installs monitor-oxc's ~3000
+      # node_modules (~40s), which this job never touches — the classifier is
+      # node-builtins-only and the target repo installs its own dependencies.
+      # The runner image's preinstalled node + corepack are sufficient.
+      - run: corepack enable
+
+      - name: Cache target repo node_modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target-repo/node_modules
+          key: runtime-${{ matrix.name }}-${{ matrix.sha }}
+
+      - run: node scripts/runtime-test.mjs install ${{ matrix.name }} target-repo
+
+      - run: ./monitor-oxc runtime-minify --name ${{ matrix.name }} --dir target-repo
+
+      - run: node scripts/runtime-test.mjs test ${{ matrix.name }} target-repo
+        env:
+          RUST_BACKTRACE: "1"
+
   runtime-bundles:
     name: Test Runtime Bundles
     needs: build
@@ -423,7 +484,7 @@ jobs:
   # wrong skip.
   record:
     name: Record green run
-    needs: [build, test, isolated_declarations, test262, runtime-bundles, uglify-corpus]
+    needs: [build, test, isolated_declarations, test262, runtime, runtime-bundles, uglify-corpus]
     # success() = every needed job succeeded (false if any failed OR was
     # skipped on the guard-hit path). The oxc SHA agreement check guards the
     # race where oxc main advances between Build's and Test262's independent

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@
 
 * Test against vue
 
+### Runtime Correctness
+
+* clone pinned popular repos ([runtime-repos.json](./runtime-repos.json))
+* minify their sources in place (transform + compress + mangle + whitespace)
+* run each repo's own test suite against the minified sources
+* a failure with a green unminified baseline = real minifier/transformer bug
+
 ### Runtime Bundles
 
 * minify production mega-bundles already in node_modules ([bundle-tools.json](./bundle-tools.json): tsc, prettier, sass, rollup, vite, vue-compiler-sfc, jiti, terser, webpack, vitest, jest-core, jest-runtime, jest-circus, babel-standalone, babel-parser, babel-core)

--- a/fixtures/runtime/zod-vitest.config.mjs
+++ b/fixtures/runtime/zod-vitest.config.mjs
@@ -1,0 +1,17 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+const c = ["@zod/source", "default"];
+export default defineConfig({
+  resolve: { conditions: c, externalConditions: c },
+  ssr: { resolve: { conditions: c, externalConditions: c } },
+  test: {
+    name: "zod",
+    root: resolve(process.cwd(), "packages/zod"),
+    include: ["src/**/*.test.ts"],
+    watch: false,
+    isolate: true,
+    setupFiles: [resolve(process.cwd(), "scripts/fail-on-console.ts")],
+    typecheck: { enabled: false },
+    silent: true,
+  },
+});

--- a/runtime-repos.json
+++ b/runtime-repos.json
@@ -1,0 +1,73 @@
+[
+  {
+    "name": "es-toolkit",
+    "repo": "toss/es-toolkit",
+    "sha": "c3d530a31be5b696317b49384257811f9d767118",
+    "sources": [
+      "src/**/*.ts"
+    ],
+    "ignore": [
+      "**/*.spec.ts",
+      "src/compat/array/find.ts",
+      "src/compat/array/findLast.ts"
+    ],
+    "install": "yarn install && yarn add @oxc-project/runtime@$OXC_RUNTIME_VERSION",
+    "test": "yarn vitest run --coverage=false --exclude '**/check-dist.spec.ts'",
+    "notes": "yarn 4 (PnP) via corepack; install adds @oxc-project/runtime so the transformer's lowered helper imports resolve. find.ts/findLast.ts ignored: their tests assert the runtime TypeError text 'doesMatch is not a function', which mangling renames (name-sensitivity, not a semantic bug). tests/check-dist.spec.ts excluded: it runs `yarn pack`->build (tsdown dts bundle) which fails on minified .ts because type-only exports are stripped -- a build/dts-tooling gate, not a runtime bug."
+  },
+  {
+    "name": "zod",
+    "repo": "colinhacks/zod",
+    "sha": "912f0f51b0ced654d0069741e7160834dca742ee",
+    "sources": [
+      "packages/zod/src/**/*.ts"
+    ],
+    "ignore": [
+      "**/*.test.ts",
+      "**/tests/**"
+    ],
+    "install": "pnpm install --frozen-lockfile && pnpm --filter zod add @oxc-project/runtime@$OXC_RUNTIME_VERSION && cp \"$MONITOR_ROOT/fixtures/runtime/zod-vitest.config.mjs\" vitest.minified.mjs",
+    "test": "pnpm vitest run --config vitest.minified.mjs",
+    "notes": "pnpm monorepo. The zod vitest project hard-enables tsc typecheck (checker:tsc, projects:['packages/*']), which cannot be disabled via CLI and legitimately fails on minified .ts (types are stripped) -- a static type gate, not a runtime bug. install copies fixtures/runtime/zod-vitest.config.mjs (via $MONITOR_ROOT, exported by scripts/runtime-test.mjs) to vitest.minified.mjs, a standalone config that keeps zod's resolve conditions (@zod/source -> src), the fail-on-console setup, and all src/**/*.test.ts runtime tests, but sets typecheck.enabled=false. install also adds @oxc-project/runtime so the transformer's lowered helper imports resolve. All 168 runtime test files / 1959 runtime tests pass on minified source."
+  },
+  {
+    "name": "vue",
+    "repo": "vuejs/core",
+    "sha": "c0606e91798c8dca4f33d101e1dd836d672592c1",
+    "sources": [
+      "packages/*/src/**/*.ts"
+    ],
+    "ignore": [
+      "packages/compiler-core/src/transforms/transformElement.ts"
+    ],
+    "install": "pnpm install --frozen-lockfile && pnpm add -w @oxc-project/runtime@$OXC_RUNTIME_VERSION",
+    "test": "pnpm exec vitest run --project 'unit*'",
+    "notes": "pnpm monorepo (pnpm@11.9.0). vitest aliases `vue`/`vue/*`/`@vue/*` -> packages/*/src/index.ts (scripts/aliases.js), so tests execute the minified SOURCE directly; no build needed. test runs only the unit projects (`vitest run --project 'unit*'` = unit, unit-gc, unit-jsdom), skipping e2e/e2e-browser (playwright). install adds @oxc-project/runtime at the workspace root so the transformer's lowered helper imports resolve. IGNORE packages/compiler-core/src/transforms/transformElement.ts: NOT an oxc bug -- the minified output is correct JS (V8 runs it; binding graph provably preserved). The 377 failures come from a vite ssrTransform scope bug: vite's SSR import-rewriter does not treat switch blocks as lexical scopes (blockNodeTypeRE in packages/vite/src/node/ssr/ssrTransform.ts omits SwitchStatement), so a let/const in a switch case (here mangled classProp/styleProp/hasDynamicKey -> o/s/a, colliding with imports createObjectProperty/createSimpleExpression/createObjectExpression) is mis-scoped to the whole buildProps body; every same-named import reference in the function is left un-rewritten -> ReferenceError: o/a is not defined at runtime. Pinned toolchain: vite@8.1.0 (rolldown-vite) + vitest@4.1.9. This is a vitest/vite module-transform artifact, latent in stock vue and surfaced by our (correct) minification; same class as vitejs/vite#5472/#3803/#4049. Remove this ignore when vite fixes ssrTransform switch scoping. With the file ignored the other 231 src files minify green: 181 test files / 3607 tests pass."
+  },
+  {
+    "name": "svelte",
+    "repo": "sveltejs/svelte",
+    "sha": "8fb7ceeba5dd1d3b7fc3f587f4e2138bf1b978ed",
+    "sources": [
+      "packages/svelte/src/**/*.js"
+    ],
+    "ignore": [],
+    "install": "pnpm install --frozen-lockfile && pnpm -F svelte add @oxc-project/runtime@$OXC_RUNTIME_VERSION",
+    "test": "pnpm exec vitest run --exclude '**/runtime-browser/test.ts'",
+    "notes": "pnpm monorepo (pnpm@10.4.0). vitest resolves `svelte`/`svelte/*` via a customResolver over packages/svelte/package.json `exports`, which all point at ./src/* (svelte 5 source is JS+JSDoc; there is no dist), so tests execute the minified SOURCE; no build needed. The compiler is also served from src (`svelte/compiler` -> ./src/compiler), so the snapshot tests that compare compiled OUTPUT stay invariant under semantically-correct minify. test excludes tests/runtime-browser/test.ts, which launches Playwright chromium (a browser gate, unavailable on the runner) -- the node-runnable SSR variant test-ssr.ts is kept. install adds @oxc-project/runtime for the transformer's lowered helper imports. Processed 369 files; 7557 tests / 32 files pass on minified source (63 skipped)."
+  },
+  {
+    "name": "solid",
+    "repo": "solidjs/solid",
+    "sha": "d2f81d546d5dff37aa25e4fa224e2192efec8c1a",
+    "sources": [
+      "packages/solid/src/**/*.ts",
+      "packages/solid/store/src/**/*.ts",
+      "packages/solid/web/src/**/*.ts"
+    ],
+    "ignore": [],
+    "install": "pnpm install --frozen-lockfile && pnpm -F solid-js add @oxc-project/runtime@$OXC_RUNTIME_VERSION",
+    "test": "pnpm -F solid-js test",
+    "notes": "pnpm monorepo (pnpm@9.15.0). packages/solid/vite.config.mjs aliases solid-js -> packages/solid/src, solid-js/web -> web/src, solid-js/jsx-runtime -> src/jsx; the tests import ../src directly, so tests execute the minified SOURCE; no build needed. sources cover src + store/src + web/src, matching the repo's own vitest coverage `include` (the trees the spec/tsx suites exercise). test runs only the solid-js package's `vitest run` (via `-F solid-js`), skipping test-types (tsc --project, a type gate that fails on stripped types) and the sibling workspace packages. install adds @oxc-project/runtime for the transformer's lowered helper imports. Processed 23 files; 482 tests / 27 files pass on minified source."
+  }
+]

--- a/scripts/runtime-test.mjs
+++ b/scripts/runtime-test.mjs
@@ -1,0 +1,82 @@
+// Differential runtime harness for `runtime-repos.json` entries.
+//
+// Usage: node scripts/runtime-test.mjs <install|baseline|test> <name> <dir> [config]
+//
+//   install  — run the repo's install command.
+//   baseline — run the repo's test suite once (untouched sources).
+//   test     — classify a minified run:
+//                minified green                -> exit 0
+//                red once, green on rerun      -> exit 0 (flake)
+//                red twice, baseline green     -> exit 1 (oxc bug)
+//                red twice, baseline red       -> exit 0 + ::warning:: (rot)
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const [mode, name, dir, configPath = "runtime-repos.json"] = process.argv.slice(2);
+
+if (!["install", "baseline", "test"].includes(mode) || !name || !dir) {
+  console.error(
+    "usage: node scripts/runtime-test.mjs <install|baseline|test> <name> <dir> [config]",
+  );
+  process.exit(2);
+}
+
+const repos = JSON.parse(fs.readFileSync(configPath, "utf8"));
+const repo = repos.find((r) => r.name === name);
+if (!repo) {
+  console.error(`no repo named \`${name}\` in ${configPath}`);
+  process.exit(2);
+}
+
+// Pin `@oxc-project/runtime` to the version resolved in monitor-oxc's own
+// committed lockfile (kept fresh by renovate), so install commands don't
+// float on the registry's `latest` tag: a publish between the weekly bump
+// run and a later CI run would otherwise change this oracle's inputs.
+const runtimeVersionMatch = fs
+  .readFileSync("pnpm-lock.yaml", "utf8")
+  .match(/'@oxc-project\/runtime':\s*\n\s*specifier:[^\n]*\n\s*version:\s*(\S+)/);
+if (!runtimeVersionMatch) {
+  console.error("could not resolve @oxc-project/runtime from pnpm-lock.yaml");
+  process.exit(2);
+}
+
+function run(command) {
+  console.log(`$ ${command}`);
+  const { status } = spawnSync(command, {
+    cwd: dir,
+    shell: true,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      // Lets install/test commands reference committed fixtures (e.g.
+      // "$MONITOR_ROOT/fixtures/runtime/...") regardless of where the clone is.
+      MONITOR_ROOT: process.cwd(),
+      OXC_RUNTIME_VERSION: runtimeVersionMatch[1],
+    },
+  });
+  return status === 0;
+}
+
+switch (mode) {
+  case "install":
+    process.exit(run(repo.install) ? 0 : 1);
+  case "baseline":
+    process.exit(run(repo.test) ? 0 : 1);
+  case "test": {
+    if (run(repo.test)) process.exit(0);
+    console.log("Minified suite failed once; rerunning to rule out a flake.");
+    if (run(repo.test)) process.exit(0);
+    console.log("Restoring original sources for the baseline run.");
+    if (!run("git checkout -- .")) process.exit(2);
+    if (run(repo.test)) {
+      console.log(
+        `Baseline passes but the minified suite fails: minifier/transformer bug (${name}).`,
+      );
+      process.exit(1);
+    }
+    console.log(
+      `::warning::Baseline suite failed for ${name} — upstream flake or environment rot, not an oxc bug.`,
+    );
+    process.exit(0);
+  }
+}


### PR DESCRIPTION
Second half of the runtime-correctness work (stacked on the bundle diff oracle PR, which carries the shared `runtime-minify` subcommand): run real repos' own test suites against their minified sources.

## Repo suites (`Test Runtime (<name>)`, 5 matrix rows)

The set favors framework monorepos with huge suites — vue (3,607 tests), svelte (7,557), solid (482) — plus es-toolkit and zod (big TS libraries). Repos whose tests import built dist (vitest, astro) are structurally out of scope: the classifier's `git checkout` restore can't rebuild gitignored dist, so this oracle is src-alias repos only. Per row:

1. **Checkout** the pinned repo (pins in [`runtime-repos.json`](./runtime-repos.json)) into `target-repo/`; the pin means the only variable is oxc itself.
2. **Install** via `scripts/runtime-test.mjs install <name> target-repo` (per-entry quirks documented in `notes`).
3. **Minify in place** with `runtime-minify` — filenames/extensions preserved, so minified JS inside a `.ts` file flows through vitest/jest transpilation untouched. Only shipped source is matched, never tests: original assertions run against minified implementation.
4. **Classify** differentially:

```
run suite on minified sources
├─ green ──────────────────────────→ pass
└─ red → rerun once
   ├─ green ───────────────────────→ pass (flake absorbed)
   └─ red → git checkout -- .  → run suite unminified
      ├─ green → FAIL   ← real minifier/transformer bug
      └─ red   → pass + ::warning::  (env/flake rot, not oxc)
```

A row can only fail when the identical tests on the identical machine pass unminified and fail minified — upstream breakage and flaky tests are structurally unable to produce a false red. TS repos route through `oxc_transformer` first, so the oracle also catches transformer runtime bugs. A weekly workflow (`bump-runtime-repos.yml`) re-pins repos whose HEAD baseline passes, via PR, so CI on the bump PR validates new pins minified before merge.

## Notes

- **It already caught a real upstream bug — in vite, not oxc**: vetting the vue entry produced 377 deterministic failures that initially looked like a mangler scope collision. Systematic follow-up exonerated oxc (697/697 references bind identically; plain Node runs the minified file) and pinned the real cause: vite's `ssrTransform` doesn't treat `switch` blocks as lexical scopes, so switch-case `let`s mis-scope and same-named import references are left un-rewritten. Fixed upstream in vitejs/vite#22893; the one file is `ignore`d with the full analysis in its `notes` (remove when the fix propagates to rolldown-vite). Cross-check: terser's output triggers the same vite bug; esbuild/swc escape only by name-allocation luck.
- Process rule encoded by that episode: a red verdict gets plain-node confirmation before blaming oxc — the suite's own module-transform layer is part of the executed stack.
- Runtime rows skip the monitor-oxc install (~40s/row): the classifier is node-builtins-only and target repos install their own deps.
- First live CI validation passed on the pre-split draft (#189): all rows green, fresh-runner installs fine, matrix rows tracked by the status comment.
