### PR TITLE
feat: add uglify corpus differential oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,45 @@ jobs:
           name: bundle-diff-artifacts
           path: bundle-diff-artifacts/
 
+  uglify-corpus:
+    name: Test Uglify Corpus
+    needs: build
+    # See `test` — break the transitive skip from the guard.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: monitor-oxc
+
+      - run: chmod +x ./monitor-oxc
+
+      - id: pin
+        run: echo "sha=$(jq -r .sha uglify-corpus.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout mishoo/UglifyJS
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: mishoo/UglifyJS
+          ref: ${{ steps.pin.outputs.sha }}
+          path: uglify-corpus-clone
+
+      - run: node scripts/uglify-corpus-test.mjs uglify-corpus-clone
+        env:
+          RUST_BACKTRACE: "1"
+
+      - name: Upload mismatch artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: ignore
+          name: uglify-corpus-artifacts
+          path: uglify-corpus-artifacts/
+
   isolated_declarations:
     needs: build
     name: Test Isolated Declarations
@@ -384,7 +423,7 @@ jobs:
   # wrong skip.
   record:
     name: Record green run
-    needs: [build, test, isolated_declarations, test262, runtime-bundles]
+    needs: [build, test, isolated_declarations, test262, runtime-bundles, uglify-corpus]
     # success() = every needed job succeeded (false if any failed OR was
     # skipped on the guard-hit path). The oxc SHA agreement check guards the
     # race where oxc main advances between Build's and Test262's independent

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 
 /dist
 bundle-diff-artifacts/
+uglify-corpus-artifacts/
 fixtures/bundle/vitest/node_modules/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@
 * run each tool on fixed fixtures before and after minification
 * byte-diff the outputs — differential by construction, so no pins or baselines needed
 
+### Uglify Corpus
+
+* run UglifyJS's `test/compress` cases ([uglify-corpus.json](./uglify-corpus.json) pins the corpus)
+* execute each tiny case before and after minification in a vm sandbox
+* diff the output — failures are pre-minimized compressor-semantics repros
+
 ## Top 3000 npm packages from [npm-high-impact](https://github.com/wooorm/npm-high-impact)
 
 (check out our [package.json](https://github.com/oxc-project/monitor-oxc/blob/main/package.json) 😆)

--- a/scripts/uglify-corpus-test.mjs
+++ b/scripts/uglify-corpus-test.mjs
@@ -1,0 +1,745 @@
+// Differential runtime oracle over UglifyJS's `test/compress` corpus.
+//
+// Usage: node scripts/uglify-corpus-test.mjs <uglify-clone-dir>
+//   env MONITOR_OXC_BIN overrides the binary path (default `./monitor-oxc`).
+//   Exit 0 = every non-skipped case ran identically before and after minify.
+//   Exit 1 = a runtime diff or a minify failure (writes evidence to
+//            uglify-corpus-artifacts/). Exit 2 = usage/config/corpus error.
+//
+// How it works (purely differential — the corpus's own `expect_stdout`
+// strings are NEVER trusted; expected output is always produced by executing
+// the ORIGINAL case in this run):
+//
+//   1. Parse each `test/compress/*.js` DSL file. Every top-level labelled
+//      block is one case: `name: { options=..., input: {...}, expect: ...,
+//      expect_stdout: ..., node_version: ... }`. A tiny brace/token scanner
+//      (string / template / regex / comment aware) slices out the `input`
+//      block body verbatim and detects the `expect_stdout`, `expression` and
+//      `node_version` members. We implement our own minimal extractor rather
+//      than reusing uglify's AST walker because that needs uglify's parser +
+//      the `semver` npm dep, and this harness is builtins-only.
+//   2. A case is RUNNABLE iff it carries `expect_stdout` (that flag is only
+//      used as a runnable marker) and its `node_version` range admits the
+//      current node. Runnable, non-skip-listed cases are written to a scratch
+//      `cases/<file>/<name>.js` tree — expression cases wrapped in
+//      `console.log(( ... ))` so their value is observed (and not DCE'd).
+//   3. ONE `runtime-minify` invocation minifies the whole tree in place with
+//      the standard full pipeline (per-case uglify `options` are ignored, as
+//      esbuild does). Any minify diagnostic on a non-skipped case fails the
+//      run — that is parser/minifier signal, not noise; such corpus files are
+//      instead seeded into the skip list with a reason.
+//   4. Each case is executed original-vs-minified in fresh `vm` contexts using
+//      a port of uglify's `test/sandbox.js` semantics (captured stdout,
+//      Function.prototype.toString normalisation so renamed functions print
+//      identically, `F######N` id stripping, 5s timeout). The original is run
+//      twice as a determinism gate; a case that differs across its two
+//      original runs is nondeterministic and auto-skipped with `::warning::`,
+//      never a red. A deterministic original/minified stdout diff is a bug.
+//
+// `.js` files are parsed unambiguously by the pipeline, so a case using
+// top-level import/export becomes a module and cannot run in `vm`'s script
+// mode; such files live in the skip list.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import util from "node:util";
+import vm from "node:vm";
+
+// A case's async body can reject *after* its synchronous portion (all we
+// capture and compare) has run. Swallow those late rejections so they neither
+// pollute stderr nor trip Node's default reject-throws exit — uglify's own
+// sandbox does the same with `process.on("unhandledRejection", () => {})`.
+process.on("unhandledRejection", () => {});
+
+// ---------------------------------------------------------------------------
+// CLI / config
+// ---------------------------------------------------------------------------
+
+function usage(msg) {
+  if (msg) console.error(msg);
+  console.error("usage: node scripts/uglify-corpus-test.mjs <uglify-clone-dir>");
+  process.exit(2);
+}
+
+const argv = process.argv.slice(2).filter((a) => a !== "");
+if (argv.length !== 1 || argv[0] === "-h" || argv[0] === "--help") usage();
+const cloneDir = argv[0];
+
+const bin = process.env.MONITOR_OXC_BIN ?? "./monitor-oxc";
+const configPath = "uglify-corpus.json";
+
+const compressDir = path.join(cloneDir, "test", "compress");
+if (!fs.existsSync(compressDir)) {
+  usage(`corpus dir not found: ${compressDir} (is \`${cloneDir}\` a UglifyJS checkout?)`);
+}
+
+let corpus;
+try {
+  corpus = JSON.parse(fs.readFileSync(configPath, "utf8"));
+} catch (err) {
+  console.error(`failed to read ${configPath}: ${err.message}`);
+  process.exit(2);
+}
+if (!corpus || typeof corpus !== "object" || !Array.isArray(corpus.skips)) {
+  console.error(`${configPath} must be an object with a "skips" array`);
+  process.exit(2);
+}
+
+// skip index: file -> { whole: reason|null, names: Map<name, reason> }
+const skipIndex = new Map();
+for (const skip of corpus.skips) {
+  if (!skip || typeof skip.file !== "string" || typeof skip.reason !== "string") {
+    console.error(`${configPath}: every skip needs string "file" and "reason"`);
+    process.exit(2);
+  }
+  let entry = skipIndex.get(skip.file);
+  if (!entry) {
+    entry = { whole: null, names: new Map() };
+    skipIndex.set(skip.file, entry);
+  }
+  if (skip.name === undefined) entry.whole = skip.reason;
+  else entry.names.set(skip.name, skip.reason);
+}
+function skipReason(file, name) {
+  const entry = skipIndex.get(file);
+  if (!entry) return null;
+  if (entry.whole !== null) return entry.whole;
+  return entry.names.get(name) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal token-aware scanner for the uglify test DSL
+// ---------------------------------------------------------------------------
+
+function skipString(src, i) {
+  const quote = src[i++];
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "\\") i += 2;
+    else if (c === quote) return i + 1;
+    else i++;
+  }
+  return i;
+}
+
+function skipTemplate(src, i) {
+  i++; // opening backtick
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "\\") {
+      i += 2;
+    } else if (c === "`") {
+      return i + 1;
+    } else if (c === "$" && src[i + 1] === "{") {
+      i = matchBrace(src, i + 1); // skip ${ ... }
+    } else {
+      i++;
+    }
+  }
+  return i;
+}
+
+// Regex-vs-division: a `/` begins a regex unless the previous significant
+// token could end an expression (identifier, number, `)`, `]`, `}`, `.`).
+function regexAllowed(src, i) {
+  let j = i - 1;
+  while (j >= 0) {
+    const c = src[j];
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") { j--; continue; }
+    // skip a preceding line/block comment
+    if (c === "/" && src[j - 1] === "/") { j -= 2; continue; }
+    break;
+  }
+  if (j < 0) return true;
+  const c = src[j];
+  if (/[)\]}]/.test(c)) return false;
+  if (/[\w$]/.test(c)) {
+    // keyword (return, typeof, ...) => regex; identifier/number => division
+    let k = j;
+    while (k >= 0 && /[\w$]/.test(src[k])) k--;
+    const word = src.slice(k + 1, j + 1);
+    return /^(return|typeof|instanceof|in|of|new|delete|void|do|else|yield|await|case)$/.test(word);
+  }
+  return true;
+}
+
+function skipRegex(src, i) {
+  i++; // opening slash
+  let inClass = false;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "\\") { i += 2; continue; }
+    if (c === "[") inClass = true;
+    else if (c === "]") inClass = false;
+    else if (c === "/" && !inClass) { i++; break; }
+    else if (c === "\n") break; // unterminated; bail
+    i++;
+  }
+  while (i < src.length && /[a-z]/i.test(src[i])) i++; // flags
+  return i;
+}
+
+// Given index of an opening `{`, return the index just past its match.
+function matchBrace(src, open) {
+  let depth = 0;
+  let i = open;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "/") {
+      const n = src[i + 1];
+      if (n === "/") { const e = src.indexOf("\n", i + 2); i = e < 0 ? src.length : e; continue; }
+      if (n === "*") { const e = src.indexOf("*/", i + 2); i = e < 0 ? src.length : e + 2; continue; }
+      if (regexAllowed(src, i)) { i = skipRegex(src, i); continue; }
+      i++; continue;
+    }
+    if (c === '"' || c === "'") { i = skipString(src, i); continue; }
+    if (c === "`") { i = skipTemplate(src, i); continue; }
+    if (c === "{") { depth++; i++; continue; }
+    if (c === "}") { depth--; i++; if (depth === 0) return i; continue; }
+    i++;
+  }
+  return -1;
+}
+
+const IDENT_START = /[A-Za-z_$]/;
+
+// Skip whitespace and comments; return next index.
+function skipTrivia(src, i) {
+  while (i < src.length) {
+    const c = src[i];
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") { i++; continue; }
+    if (c === "/" && src[i + 1] === "/") { const e = src.indexOf("\n", i + 2); i = e < 0 ? src.length : e; continue; }
+    if (c === "/" && src[i + 1] === "*") { const e = src.indexOf("*/", i + 2); i = e < 0 ? src.length : e + 2; continue; }
+    break;
+  }
+  return i;
+}
+
+// Parse the top-level cases of a corpus file: `name: { ... }` labelled blocks.
+function parseCases(src) {
+  const cases = [];
+  let i = 0;
+  while (i < src.length) {
+    i = skipTrivia(src, i);
+    if (i >= src.length) break;
+    if (!IDENT_START.test(src[i])) { i++; continue; }
+    let j = i;
+    while (j < src.length && /[\w$]/.test(src[j])) j++;
+    const name = src.slice(i, j);
+    const afterName = skipTrivia(src, j);
+    if (src[afterName] !== ":") { i = j; continue; }
+    const afterColon = skipTrivia(src, afterName + 1);
+    if (src[afterColon] !== "{") { i = afterColon; continue; }
+    const end = matchBrace(src, afterColon);
+    if (end < 0) break;
+    const body = src.slice(afterColon + 1, end - 1);
+    cases.push({ name, body });
+    i = end;
+  }
+  return cases;
+}
+
+// Within a case body, locate the `input: { ... }` block and read the flat
+// members we care about. Returns { input, hasStdout, expression, nodeVersion }.
+function parseCaseBody(body) {
+  let input = null;
+  let inputStart = -1;
+  let inputEnd = -1;
+  let hasStdout = false;
+  let expression = false;
+  let nodeVersion = null;
+
+  let i = 0;
+  while (i < body.length) {
+    i = skipTrivia(body, i);
+    if (i >= body.length) break;
+    if (!IDENT_START.test(body[i])) { i++; continue; }
+    let j = i;
+    while (j < body.length && /[\w$]/.test(body[j])) j++;
+    const member = body.slice(i, j);
+    const afterName = skipTrivia(body, j);
+    const sep = body[afterName];
+
+    if (sep === ":") {
+      const valStart = skipTrivia(body, afterName + 1);
+      if (body[valStart] === "{") {
+        const end = matchBrace(body, valStart);
+        if (member === "input") {
+          input = body.slice(valStart + 1, end - 1);
+          inputStart = i;
+          inputEnd = end;
+        }
+        i = end < 0 ? body.length : end;
+        continue;
+      }
+      if (member === "expect_stdout") hasStdout = true;
+      if (member === "node_version") {
+        const q = body[valStart];
+        if (q === '"' || q === "'") {
+          const strEnd = skipString(body, valStart);
+          nodeVersion = body.slice(valStart + 1, strEnd - 1);
+        }
+      }
+      // advance past this value (string / array / call / etc.)
+      i = skipValue(body, valStart);
+      continue;
+    }
+    if (sep === "=") {
+      const valStart = skipTrivia(body, afterName + 1);
+      if (member === "expression" && /^true\b/.test(body.slice(valStart))) expression = true;
+      i = skipValue(body, valStart);
+      continue;
+    }
+    i = j;
+  }
+  return { input, inputStart, inputEnd, hasStdout, expression, nodeVersion };
+}
+
+// Advance past a member value (object, array, call, string, literal) until the
+// next member starts or the body ends.
+function skipValue(src, i) {
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "/") {
+      const n = src[i + 1];
+      if (n === "/") { const e = src.indexOf("\n", i + 2); i = e < 0 ? src.length : e; continue; }
+      if (n === "*") { const e = src.indexOf("*/", i + 2); i = e < 0 ? src.length : e + 2; continue; }
+      if (regexAllowed(src, i)) { i = skipRegex(src, i); continue; }
+      i++; continue;
+    }
+    if (c === '"' || c === "'") { i = skipString(src, i); continue; }
+    if (c === "`") { i = skipTemplate(src, i); continue; }
+    if (c === "{" || c === "[" || c === "(") { i = matchBracket(src, i); continue; }
+    if (c === "\n") {
+      // A newline at depth 0 ends the value if a new member follows.
+      const k = skipTrivia(src, i + 1);
+      if (k >= src.length) return k;
+      if (IDENT_START.test(src[k])) {
+        let m = k;
+        while (m < src.length && /[\w$]/.test(src[m])) m++;
+        const after = skipTrivia(src, m);
+        if (src[after] === ":" || src[after] === "=") return i + 1;
+      }
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+// Match any bracket kind `{}` `[]` `()` from its opening index.
+function matchBracket(src, open) {
+  const pairs = { "{": "}", "[": "]", "(": ")" };
+  const stack = [pairs[src[open]]];
+  let i = open + 1;
+  while (i < src.length && stack.length) {
+    const c = src[i];
+    if (c === "/") {
+      const n = src[i + 1];
+      if (n === "/") { const e = src.indexOf("\n", i + 2); i = e < 0 ? src.length : e; continue; }
+      if (n === "*") { const e = src.indexOf("*/", i + 2); i = e < 0 ? src.length : e + 2; continue; }
+      if (regexAllowed(src, i)) { i = skipRegex(src, i); continue; }
+      i++; continue;
+    }
+    if (c === '"' || c === "'") { i = skipString(src, i); continue; }
+    if (c === "`") { i = skipTemplate(src, i); continue; }
+    if (c === "{" || c === "[" || c === "(") { stack.push(pairs[c]); i++; continue; }
+    if (c === "}" || c === "]" || c === ")") {
+      if (stack[stack.length - 1] === c) stack.pop();
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+// ---------------------------------------------------------------------------
+// node_version range check (minimal; conservative: unknown => not satisfied)
+// ---------------------------------------------------------------------------
+
+function parseVersion(v) {
+  const m = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)];
+}
+function cmp(a, b) {
+  for (let k = 0; k < 3; k++) if (a[k] !== b[k]) return a[k] < b[k] ? -1 : 1;
+  return 0;
+}
+function satisfiesComparator(version, token) {
+  const m = /^(>=|<=|>|<|=)?\s*(.+)$/.exec(token.trim());
+  if (!m) return false;
+  const op = m[1] ?? "=";
+  const target = parseVersion(m[2]);
+  if (!target) return false;
+  // Fill missing components: for upper bounds treat as +Infinity so e.g.
+  // `<=10` admits 10.22.0; a bare/exact token matches on given precision.
+  const c = cmp(version, target);
+  switch (op) {
+    case ">=": return c >= 0;
+    case ">": return c > 0;
+    case "<=": {
+      const parts = m[2].trim().split(".").length;
+      const upper = [target[0], parts > 1 ? target[1] : Infinity, parts > 2 ? target[2] : Infinity];
+      return cmp(version, upper) <= 0;
+    }
+    case "<": return cmp(version, target) < 0;
+    default: {
+      // bare/exact: match on the precision given (e.g. "4" => major 4)
+      const parts = m[2].trim().split(".").length;
+      for (let k = 0; k < parts; k++) if (version[k] !== target[k]) return false;
+      return true;
+    }
+  }
+}
+function nodeSatisfies(range, versionStr) {
+  const version = parseVersion(versionStr);
+  if (!version) return false;
+  return range.split("||").some((group) =>
+    group.trim().split(/\s+/).filter(Boolean).every((tok) => satisfiesComparator(version, tok)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// vm sandbox (port of uglify test/sandbox.js run_code_vm semantics)
+// ---------------------------------------------------------------------------
+
+// Match uglify's util.inspect setup so object/array logging is deterministic.
+function setupLog() {
+  const inspect = util.inspect;
+  if (inspect.defaultOptions) {
+    const logOptions = {
+      breakLength: Infinity,
+      colors: false,
+      compact: true,
+      customInspect: false,
+      depth: Infinity,
+      maxArrayLength: Infinity,
+      maxStringLength: Infinity,
+      showHidden: false,
+    };
+    for (const name in logOptions) {
+      if (name in inspect.defaultOptions) inspect.defaultOptions[name] = logOptions[name];
+    }
+  }
+  return inspect;
+}
+
+// uglify's in-context setup: normalise Function#toString (so minifier renames
+// don't change logged function bodies), install a safe console.log, expose
+// global/self/window, delete host builtins. Copied semantically from
+// test/sandbox.js `setup`.
+function setup(global, builtins, setupLog) {
+  [Array, Boolean, Error, Function, Number, Object, RegExp, String].forEach((f) => {
+    f.toString = Function.prototype.toString;
+  });
+  Function.prototype.toString = (function () {
+    const configurable = Object.getOwnPropertyDescriptor(Function.prototype, "name").configurable;
+    let id = 100000;
+    return function () {
+      let n = this.name;
+      if (!/^F[0-9]{6}N$/.test(n)) {
+        n = "F" + ++id + "N";
+        if (configurable) Object.defineProperty(this, "name", { get: () => n });
+      }
+      return "function(){}";
+    };
+  })();
+  const log = console.log;
+  const safeConsole = {
+    log: function (msg) {
+      if (arguments.length === 1 && typeof msg === "string") return log("%s", msg);
+      return log.apply(null, [].map.call(arguments, (arg) =>
+        safeLog(arg, { level: 5, original: [], replaced: [] }),
+      ));
+    },
+  };
+  const props = {
+    console: { get: () => safeConsole },
+    global: { get: self },
+    self: { get: self },
+    window: { get: self },
+  };
+  builtins.forEach((name) => {
+    try { delete global[name]; } catch (e) {}
+  });
+  Object.defineProperties(global, props);
+  global.__proto__ = Object.defineProperty(Object.create(global.__proto__), "toString", {
+    value: () => "[object global]",
+  });
+
+  function self() { return this; }
+
+  function safeLog(arg, cache) {
+    if (arg) switch (typeof arg) {
+      case "function":
+        return arg.toString();
+      case "object":
+        if (arg === global) return "[object global]";
+        if (/Error$/.test(arg.name)) return arg.toString();
+        if (typeof arg.then === "function") return "[object Promise]";
+        if (arg.constructor) arg.constructor.toString();
+        var index = cache.original.indexOf(arg);
+        if (index >= 0) return cache.replaced[index];
+        if (--cache.level < 0) return "[object Object]";
+        var value = {};
+        cache.original.push(arg);
+        cache.replaced.push(value);
+        for (var key in arg) {
+          var desc = Object.getOwnPropertyDescriptor(arg, key);
+          if (desc && (desc.get || desc.set)) Object.defineProperty(value, key, desc);
+          else value[key] = safeLog(arg[key], cache);
+        }
+        return value;
+    }
+    return arg;
+  }
+}
+
+setupLog();
+
+function stripColorCodes(value) {
+  return value.replace(/\[\d+m/g, "");
+}
+function stripFuncIds(text) {
+  return ("" + text).replace(/F[0-9]{6}N/g, "<F<>N>");
+}
+function isError(result) {
+  return result && typeof result.name === "string" && typeof result.message === "string";
+}
+
+// Build the in-context setup code exactly like sandbox.js: `(setup)(this,
+// <builtins>, setupLog);`. Builtins are the context globals to delete, found
+// by logging Object.keys(this) from a bare run.
+function runVm(prelude, code, timeout = 5000) {
+  let stdout = "";
+  const originalWrite = process.stdout.write;
+  process.stdout.write = (chunk) => { stdout += chunk; return true; };
+  try {
+    const ctx = vm.createContext({ console });
+    if (prelude) vm.runInContext(prelude, ctx);
+    vm.runInContext(code, ctx, { timeout });
+    return {
+      stdout: stripColorCodes(stdout.replace(/\b(Array \[|Object {)/g, (m) => m.slice(-1))),
+    };
+  } catch (ex) {
+    if (ex && (ex.code === "ERR_SCRIPT_EXECUTION_TIMEOUT" || /timed out/i.test(ex.message ?? ""))) {
+      return { timeout: true };
+    }
+    return { error: { name: ex && ex.name, message: ex && ex.message } };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+const builtinsLiteral = (runVm("", "console.log(Object.keys(this));").stdout ?? "[]").trim();
+const setupCode =
+  "(" + setup + ")(" + ["this", builtinsLiteral, setupLog].join(",\n") + ");\n";
+
+function runCase(code, timeout) {
+  return runVm(setupCode, code, timeout);
+}
+
+// uglify same_stdout: string/string compare after id stripping; error/error
+// compare name + last message line.
+function sameResult(a, b) {
+  if (a.timeout || b.timeout) return a.timeout && b.timeout;
+  const aErr = a.error && isError(a.error);
+  const bErr = b.error && isError(b.error);
+  if (aErr !== bErr) return false;
+  if (aErr) {
+    if (a.error.name !== b.error.name) return false;
+    const lastLine = (m) => m.slice(m.lastIndexOf("\n") + 1);
+    return stripFuncIds(lastLine(a.error.message)) === stripFuncIds(lastLine(b.error.message));
+  }
+  if (a.error || b.error) return false; // a non-Error throw on one side only
+  return stripFuncIds(a.stdout) === stripFuncIds(b.stdout);
+}
+
+function describe(r) {
+  if (r.timeout) return "<timeout>";
+  if (r.error) return `${r.error.name}: ${r.error.message}`;
+  return JSON.stringify(r.stdout);
+}
+
+// ---------------------------------------------------------------------------
+// Extract runnable cases
+// ---------------------------------------------------------------------------
+
+const corpusFiles = fs
+  .readdirSync(compressDir)
+  .filter((n) => /\.js$/i.test(n))
+  .sort();
+
+const stats = {
+  total: 0,
+  skipped: {}, // reason -> count
+  excluded: {}, // reason -> count
+};
+function bump(bucket, reason) {
+  bucket[reason] = (bucket[reason] ?? 0) + 1;
+}
+
+const keepScratch = process.env.UGLIFY_CORPUS_KEEP === "1";
+const scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "uglify-corpus-"));
+const casesRoot = path.join(scratchRoot, "cases");
+const runnable = []; // { file, name, rel, absPath, original, expression }
+
+for (const file of corpusFiles) {
+  const relFile = `compress/${file}`;
+  const src = fs.readFileSync(path.join(compressDir, file), "utf8");
+  let cases;
+  try {
+    cases = parseCases(src);
+  } catch (err) {
+    console.error(`failed to parse corpus file ${relFile}: ${err.message}`);
+    if (!keepScratch) fs.rmSync(scratchRoot, { recursive: true, force: true }); else console.error(`kept scratch: ${scratchRoot}`);
+    process.exit(2);
+  }
+  for (const c of cases) {
+    stats.total++;
+    const reason = skipReason(relFile, c.name);
+    if (reason !== null) {
+      bump(stats.skipped, reason);
+      continue;
+    }
+    const info = parseCaseBody(c.body);
+    if (!info.hasStdout || info.input === null) {
+      bump(stats.excluded, "not runnable (no expect_stdout)");
+      continue;
+    }
+    if (info.nodeVersion && !nodeSatisfies(info.nodeVersion, process.version)) {
+      bump(stats.excluded, "node_version gate");
+      continue;
+    }
+    let body = info.input;
+    if (info.expression) body = `console.log((\n${body.replace(/;\s*$/, "")}\n));`;
+    const rel = path.join(file.replace(/\.js$/i, ""), `${c.name}.js`);
+    const absPath = path.join(casesRoot, rel);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, body + "\n");
+    runnable.push({ file: relFile, name: c.name, rel, absPath, original: body + "\n", expression: info.expression });
+  }
+}
+
+if (runnable.length === 0) {
+  console.error("no runnable cases extracted — extractor or corpus problem");
+  if (!keepScratch) fs.rmSync(scratchRoot, { recursive: true, force: true }); else console.error(`kept scratch: ${scratchRoot}`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Minify the whole tree in one runtime-minify invocation
+// ---------------------------------------------------------------------------
+
+const minifyConfig = path.join(scratchRoot, "config.json");
+fs.writeFileSync(
+  minifyConfig,
+  JSON.stringify([{ name: "uglify-corpus", sources: ["cases/**/*.js"] }]),
+);
+
+const minify = spawnSync(
+  bin,
+  ["runtime-minify", "--config", minifyConfig, "--name", "uglify-corpus", "--dir", scratchRoot],
+  { stdio: "inherit" },
+);
+if (minify.status !== 0) {
+  console.error(
+    `runtime-minify failed (exit ${minify.status}${minify.error ? `, ${minify.error.message}` : ""}) — ` +
+      `add the offending corpus file(s) to ${configPath} skips with a reason, or fix the minifier`,
+  );
+  if (!keepScratch) fs.rmSync(scratchRoot, { recursive: true, force: true }); else console.error(`kept scratch: ${scratchRoot}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Execute + diff
+// ---------------------------------------------------------------------------
+
+const artifactsDir = "uglify-corpus-artifacts";
+let compared = 0;
+let failed = false;
+
+function saveArtifacts(item, original, minified, expected, actual) {
+  const dir = path.join(artifactsDir, item.file.replace(/[\/]/g, "_"), item.name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "original.js"), original);
+  fs.writeFileSync(path.join(dir, "minified.js"), minified);
+  fs.writeFileSync(path.join(dir, "expected.txt"), describe(expected) + "\n");
+  fs.writeFileSync(path.join(dir, "actual.txt"), describe(actual) + "\n");
+}
+
+// The transform stage lowers modern syntax (class fields/private members,
+// object spread/rest, ...) into calls to `@oxc-project/runtime` helpers, and
+// module cases keep import/export. None of that resolves in a builtins-only
+// `vm` script, so such cases are non-oracle here (runtime-helper correctness
+// is covered by the Runtime Bundles oracle, which runs in real node_modules).
+function needsModuleLoader(code) {
+  return (
+    /\brequire\s*\(\s*["'`]/.test(code) ||
+    /(^|[\n;{}])\s*(?:import|export)[\s{*]/.test(code)
+  );
+}
+
+for (const item of runnable) {
+  const minified = fs.readFileSync(item.absPath, "utf8");
+  if (needsModuleLoader(minified) || needsModuleLoader(item.original)) {
+    bump(stats.excluded, "needs module loader (transform runtime helpers / ESM)");
+    continue;
+  }
+  const first = runCase(item.original);
+
+  // Original that cannot run in this harness is a non-oracle case.
+  if (first.timeout) {
+    bump(stats.excluded, "original times out");
+    continue;
+  }
+  if (first.error && first.error.name === "SyntaxError") {
+    bump(stats.excluded, "original SyntaxError in vm (module/host syntax)");
+    continue;
+  }
+
+  const second = runCase(item.original);
+  if (!sameResult(first, second)) {
+    console.log(`::warning::${item.file} [${item.name}] is nondeterministic — skipped, not an oxc bug`);
+    bump(stats.skipped, "nondeterministic original (auto)");
+    continue;
+  }
+
+  const actual = runCase(minified);
+  if (!sameResult(first, actual)) {
+    console.error(`FAIL ${item.file} [${item.name}]: minified output DIFFERS`);
+    console.error(`  expected: ${describe(first)}`);
+    console.error(`  actual:   ${describe(actual)}`);
+    saveArtifacts(item, item.original, minified, first, actual);
+    failed = true;
+    continue;
+  }
+  compared++;
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+if (!keepScratch) fs.rmSync(scratchRoot, { recursive: true, force: true });
+else console.error(`kept scratch: ${scratchRoot}`);
+
+const skippedTotal = Object.values(stats.skipped).reduce((a, b) => a + b, 0);
+const excludedTotal = Object.values(stats.excluded).reduce((a, b) => a + b, 0);
+const fmt = (bucket) =>
+  Object.entries(bucket)
+    .sort((a, b) => b[1] - a[1])
+    .map(([r, n]) => `${r}: ${n}`)
+    .join("; ");
+
+console.log(
+  `${stats.total} cases: ${compared} compared, ${skippedTotal} skipped ` +
+    `(${fmt(stats.skipped) || "none"}), ${excludedTotal} excluded (${fmt(stats.excluded) || "none"})`,
+);
+
+process.exit(failed ? 1 : 0);

--- a/scripts/uglify-corpus-test.mjs
+++ b/scripts/uglify-corpus-test.mjs
@@ -519,21 +519,25 @@ function runVm(prelude, code, timeout = 5000) {
   let stdout = "";
   const originalWrite = process.stdout.write;
   process.stdout.write = (chunk) => { stdout += chunk; return true; };
+  let result;
   try {
     const ctx = vm.createContext({ console });
     if (prelude) vm.runInContext(prelude, ctx);
     vm.runInContext(code, ctx, { timeout });
-    return {
-      stdout: stripColorCodes(stdout.replace(/\b(Array \[|Object {)/g, (m) => m.slice(-1))),
-    };
+    result = {};
   } catch (ex) {
     if (ex && (ex.code === "ERR_SCRIPT_EXECUTION_TIMEOUT" || /timed out/i.test(ex.message ?? ""))) {
-      return { timeout: true };
+      result = { timeout: true };
+    } else {
+      result = { error: { name: ex && ex.name, message: ex && ex.message } };
     }
-    return { error: { name: ex && ex.name, message: ex && ex.message } };
   } finally {
     process.stdout.write = originalWrite;
   }
+  // Keep stdout on error results too: output produced before a throw is
+  // oracle-relevant (a dropped/reordered log ahead of the same throw is a bug).
+  result.stdout = stripColorCodes(stdout.replace(/\b(Array \[|Object {)/g, (m) => m.slice(-1)));
+  return result;
 }
 
 const builtinsLiteral = (runVm("", "console.log(Object.keys(this));").stdout ?? "[]").trim();
@@ -544,8 +548,9 @@ function runCase(code, timeout) {
   return runVm(setupCode, code, timeout);
 }
 
-// uglify same_stdout: string/string compare after id stripping; error/error
-// compare name + last message line.
+// uglify same_stdout compares errors by name + last message line only; we are
+// stricter and additionally require identical pre-throw stdout, so a minifier
+// bug that drops/reorders logs ahead of an identical final throw still fails.
 function sameResult(a, b) {
   if (a.timeout || b.timeout) return a.timeout && b.timeout;
   const aErr = a.error && isError(a.error);
@@ -554,15 +559,21 @@ function sameResult(a, b) {
   if (aErr) {
     if (a.error.name !== b.error.name) return false;
     const lastLine = (m) => m.slice(m.lastIndexOf("\n") + 1);
-    return stripFuncIds(lastLine(a.error.message)) === stripFuncIds(lastLine(b.error.message));
+    if (stripFuncIds(lastLine(a.error.message)) !== stripFuncIds(lastLine(b.error.message))) {
+      return false;
+    }
+  } else if (a.error || b.error) {
+    return false; // a non-Error throw
   }
-  if (a.error || b.error) return false; // a non-Error throw on one side only
   return stripFuncIds(a.stdout) === stripFuncIds(b.stdout);
 }
 
 function describe(r) {
   if (r.timeout) return "<timeout>";
-  if (r.error) return `${r.error.name}: ${r.error.message}`;
+  if (r.error) {
+    const error = `${r.error.name}: ${r.error.message}`;
+    return r.stdout ? `${JSON.stringify(r.stdout)} then ${error}` : error;
+  }
   return JSON.stringify(r.stdout);
 }
 

--- a/uglify-corpus.json
+++ b/uglify-corpus.json
@@ -5,7 +5,7 @@
     {
       "file": "compress/arrows.js",
       "name": "for_statement_parentheses_init",
-      "reason": "REAL OXC BUG (parser): oxc rejects `for (a => { a in a; }; ...)` — the for-init no-in restriction leaks into the arrow's block body; Node/V8 accept it. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt (uglify-bug-evidence/README.md)"
+      "reason": "REAL OXC BUG (parser): oxc rejects `for (a => { a in a; }; ...)` \u2014 the for-init no-in restriction leaks into the arrow's block body; Node/V8 accept it. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt (uglify-bug-evidence/README.md)"
     },
     {
       "file": "compress/classes.js",
@@ -135,72 +135,72 @@
     {
       "file": "compress/booleans.js",
       "name": "de_morgan_1c",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/conditionals.js",
       "name": "delete_conditional_1",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/conditionals.js",
       "name": "delete_conditional_2",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/evaluate.js",
       "name": "delete_expr_1",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/evaluate.js",
       "name": "delete_expr_2",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/evaluate.js",
       "name": "delete_binary_1",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/evaluate.js",
       "name": "delete_binary_2",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_1",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_2",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_3",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_4",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_4_evaluate",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_5",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/sequences.js",
       "name": "delete_seq_5_evaluate",
-      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) \u2014 `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
     },
     {
       "file": "compress/arrows.js",
@@ -440,22 +440,22 @@
     {
       "file": "compress/collapse_vars.js",
       "name": "collapse_vars_eval_and_with",
-      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+      "reason": "REAL OXC BUG (with-scope soundness): compressor substitutes global identifiers (Infinity -> 1/0) that a `with` object shadows at runtime; terser/esbuild guard this. Plain-node reproducible; see uglify-bug-evidence"
     },
     {
       "file": "compress/issue-1105.js",
       "name": "Infinity_in_with_scope",
-      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+      "reason": "REAL OXC BUG (with-scope soundness): compressor substitutes global identifiers (Infinity -> 1/0) that a `with` object shadows at runtime; terser/esbuild guard this. Plain-node reproducible; see uglify-bug-evidence"
     },
     {
       "file": "compress/issue-1105.js",
       "name": "assorted_Infinity_NaN_undefined_in_with_scope",
-      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+      "reason": "REAL OXC BUG (with-scope soundness): compressor substitutes global identifiers (Infinity -> 1/0) that a `with` object shadows at runtime; terser/esbuild guard this. Plain-node reproducible; see uglify-bug-evidence"
     },
     {
       "file": "compress/issue-1105.js",
       "name": "assorted_Infinity_NaN_undefined_in_with_scope_keep_infinity",
-      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+      "reason": "REAL OXC BUG (with-scope soundness): compressor substitutes global identifiers (Infinity -> 1/0) that a `with` object shadows at runtime; terser/esbuild guard this. Plain-node reproducible; see uglify-bug-evidence"
     },
     {
       "file": "compress/annotations.js",
@@ -475,52 +475,52 @@
     {
       "file": "compress/templates.js",
       "name": "ascii_only",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "ascii_only_ecma",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "ascii_only_templates",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "ascii_only_templates_ecma",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "unicode",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "unicode_ecma",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "unicode_templates",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/templates.js",
       "name": "unicode_templates_ecma",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/unicode.js",
       "name": "issue_2242_3",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/unicode.js",
       "name": "issue_2242_4",
-      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+      "reason": "REAL OXC BUG (codegen lone-surrogate): lone surrogates in strings/templates emitted lossily as U+FFFD instead of \\uXXXX escapes \u2014 plain-node-visible data loss; see uglify-bug-evidence"
     },
     {
       "file": "compress/classes.js",

--- a/uglify-corpus.json
+++ b/uglify-corpus.json
@@ -1,0 +1,541 @@
+{
+  "repo": "mishoo/UglifyJS",
+  "sha": "111746bbae5f55c88e3b82b42f14fd0f3129ea53",
+  "skips": [
+    {
+      "file": "compress/arrows.js",
+      "name": "for_statement_parentheses_init",
+      "reason": "REAL OXC BUG (parser): oxc rejects `for (a => { a in a; }; ...)` — the for-init no-in restriction leaks into the arrow's block body; Node/V8 accept it. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt (uglify-bug-evidence/README.md)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "keep_instanceof_1",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "keep_instanceof_2",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "issue_4290_1",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "issue_4305_2",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "retain_catch",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "skip_braces",
+      "reason": "deliberate SyntaxError: lexical `const` declaration in a single-statement context (Node rejects it too)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4290_1",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4305_2",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "retain_block_2",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "retain_block_3",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "retain_catch",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "skip_braces",
+      "reason": "deliberate SyntaxError: lexical `let` declaration in a single-statement context (Node rejects it too)"
+    },
+    {
+      "file": "compress/reduce_vars.js",
+      "name": "defun_catch_4",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/reduce_vars.js",
+      "name": "defun_catch_5",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/varify.js",
+      "name": "issue_4290_1_const",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/varify.js",
+      "name": "issue_4290_1_let",
+      "reason": "deliberate SyntaxError: duplicate declaration (var/let/const/class collision); not valid as a script (Node rejects it too)"
+    },
+    {
+      "file": "compress/exponentiation.js",
+      "name": "await",
+      "reason": "deliberate SyntaxError: unary op immediately before `**` without parens (Node rejects it too)"
+    },
+    {
+      "file": "compress/exponentiation.js",
+      "name": "precedence_1",
+      "reason": "deliberate SyntaxError: unary op immediately before `**` without parens (Node rejects it too)"
+    },
+    {
+      "file": "compress/exponentiation.js",
+      "name": "precedence_2",
+      "reason": "deliberate SyntaxError: unary op immediately before `**` without parens (Node rejects it too)"
+    },
+    {
+      "file": "compress/exponentiation.js",
+      "name": "precedence_3",
+      "reason": "deliberate SyntaxError: unary op immediately before `**` without parens (Node rejects it too)"
+    },
+    {
+      "file": "compress/exponentiation.js",
+      "name": "precedence_4",
+      "reason": "deliberate SyntaxError: unary op immediately before `**` without parens (Node rejects it too)"
+    },
+    {
+      "file": "compress/nullish.js",
+      "name": "parentheses",
+      "reason": "deliberate SyntaxError: `??` mixed with `||`/`&&` without parentheses (Node rejects it too)"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "malformed_evaluate_1",
+      "reason": "deliberate SyntaxError: octal escape in untagged template literal (Node rejects it too)"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "malformed_evaluate_2",
+      "reason": "deliberate SyntaxError: invalid unicode escape in untagged template literal (Node rejects it too)"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "malformed_evaluate_3",
+      "reason": "deliberate SyntaxError: invalid unicode escape in untagged template literal (Node rejects it too)"
+    },
+    {
+      "file": "compress/booleans.js",
+      "name": "de_morgan_1c",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/conditionals.js",
+      "name": "delete_conditional_1",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/conditionals.js",
+      "name": "delete_conditional_2",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/evaluate.js",
+      "name": "delete_expr_1",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/evaluate.js",
+      "name": "delete_expr_2",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/evaluate.js",
+      "name": "delete_binary_1",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/evaluate.js",
+      "name": "delete_binary_2",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_1",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_2",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_3",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_4",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_4_evaluate",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_5",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/sequences.js",
+      "name": "delete_seq_5_evaluate",
+      "reason": "REAL OXC BUG (compressor): `delete (expr)` whose operand the minifier evaluates to a bare global reference (`NaN`/`Infinity`) — `delete NaN` returns false where `delete (0, NaN)` returns true, so stdout flips. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/arrows.js",
+      "name": "issue_5495",
+      "reason": "REAL OXC BUG (compressor): eliminating a strict-mode IIFE/arrow drops its `\"use strict\"`, so `this` inside a nested plain call changes from undefined to the global object. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/exponentiation.js",
+      "name": "assignment_2",
+      "reason": "REAL OXC BUG (compressor): rewrites BigInt `a **= a` to `a **= +a`, and `+bigint` throws TypeError. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/numbers.js",
+      "name": "issue_4137",
+      "reason": "REAL OXC BUG (compressor): drops the unary `+` in `+(A=[])*(A[0]=1)`, changing numeric-coercion timing (0 becomes 1). evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/optional-chains.js",
+      "name": "call_parentheses",
+      "reason": "REAL OXC BUG (compressor): optional-chain call parenthesization changes the `this` binding of `(0, o?.f)(42)`. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/dead-code.js",
+      "name": "dead_code_2_should_warn",
+      "reason": "REAL OXC BUG (DCE): drops a throwing call (`g()`) that precedes an explicit `throw`, changing which error is observed. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/collapse_vars.js",
+      "name": "collapse_vars_arguments_1",
+      "reason": "REAL OXC BUG (collapse_vars/drop-unused): breaks sloppy-mode `arguments`<->parameter linkage, so a reassigned/renamed param no longer reflects in `arguments`. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/collapse_vars.js",
+      "name": "issue_4586_1",
+      "reason": "REAL OXC BUG (collapse_vars/drop-unused): breaks sloppy-mode `arguments`<->parameter linkage, so a reassigned/renamed param no longer reflects in `arguments`. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/drop-unused.js",
+      "name": "issue_4464_2",
+      "reason": "REAL OXC BUG (collapse_vars/drop-unused): breaks sloppy-mode `arguments`<->parameter linkage, so a reassigned/renamed param no longer reflects in `arguments`. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/drop-unused.js",
+      "name": "issue_4464_3",
+      "reason": "REAL OXC BUG (collapse_vars/drop-unused): breaks sloppy-mode `arguments`<->parameter linkage, so a reassigned/renamed param no longer reflects in `arguments`. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/collapse_vars.js",
+      "name": "issue_1666",
+      "reason": "REAL OXC BUG (mangler/reduce_vars): Annex B block-scoped function / catch-var hoisting broken by renaming or DCE. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/reduce_vars.js",
+      "name": "issue_1666",
+      "reason": "REAL OXC BUG (mangler/reduce_vars): Annex B block-scoped function / catch-var hoisting broken by renaming or DCE. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/ie.js",
+      "name": "issue_3999",
+      "reason": "REAL OXC BUG (mangler/reduce_vars): Annex B block-scoped function / catch-var hoisting broken by renaming or DCE. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/destructured.js",
+      "name": "funarg_side_effects_2",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/destructured.js",
+      "name": "funarg_side_effects_3",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/destructured.js",
+      "name": "issue_4436_Infinity",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/destructured.js",
+      "name": "issue_4436_NaN",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/destructured.js",
+      "name": "issue_4436_undefined",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/rests.js",
+      "name": "issue_4544_1",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/rests.js",
+      "name": "issue_5552_1",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/rests.js",
+      "name": "issue_5552_2",
+      "reason": "REAL OXC BUG (compressor/DCE): drops observable side effects evaluated by parameter destructuring, computed keys, or rest-parameter defaults. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/destructured.js",
+      "name": "issue_4420",
+      "reason": "REAL OXC BUG (mangler): collapses distinct catch/let bindings to one name, creating a spurious TDZ ReferenceError. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/yields.js",
+      "name": "issue_5679_1",
+      "reason": "REAL OXC BUG (compressor): async-generator `try { return } finally { ... }` compression skips the finally side effect. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/yields.js",
+      "name": "issue_5679_2",
+      "reason": "REAL OXC BUG (compressor): async-generator `try { return } finally { ... }` compression skips the finally side effect. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/yields.js",
+      "name": "issue_5679_3",
+      "reason": "REAL OXC BUG (compressor): async-generator `try { return } finally { ... }` compression skips the finally side effect. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/yields.js",
+      "name": "issue_5679_5",
+      "reason": "REAL OXC BUG (compressor): async-generator `try { return } finally { ... }` compression skips the finally side effect. evidence: .superpowers/sdd/uglify-bug-evidence/triage.txt"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "issue_4225",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "issue_4229",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "issue_4245",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/const.js",
+      "name": "use_before_init_3",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4225",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4229",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4245",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "use_before_init_3",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4276_1",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/let.js",
+      "name": "issue_4276_2",
+      "reason": "known divergence (TDZ): compressor removes/reorders let/const so the temporal-dead-zone ReferenceError no longer occurs (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "keep_extends_1",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_4721",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_4722_1",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_4722_2",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_4722_3",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_4829_1",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_4829_2",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_5015_1",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_5015_2",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_5387",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "issue_5481",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "retain_declaration",
+      "reason": "known divergence (class-extends / class-eval side effects): compressor drops an unused class whose heritage, computed key, or name-binding TDZ is observable (esbuild documents the same class)"
+    },
+    {
+      "file": "compress/collapse_vars.js",
+      "name": "collapse_vars_eval_and_with",
+      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+    },
+    {
+      "file": "compress/issue-1105.js",
+      "name": "Infinity_in_with_scope",
+      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+    },
+    {
+      "file": "compress/issue-1105.js",
+      "name": "assorted_Infinity_NaN_undefined_in_with_scope",
+      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+    },
+    {
+      "file": "compress/issue-1105.js",
+      "name": "assorted_Infinity_NaN_undefined_in_with_scope_keep_infinity",
+      "reason": "known divergence (`with` dynamic scope): compressor substitutes global identifiers that a `with` block could shadow — universally unsafe, deprecated construct"
+    },
+    {
+      "file": "compress/annotations.js",
+      "name": "issue_3858",
+      "reason": "known divergence (@__PURE__ annotation): compressor honors the pure annotation and drops the annotated call; the input deliberately hides a side effect inside it"
+    },
+    {
+      "file": "compress/evaluate.js",
+      "name": "unsafe_array",
+      "reason": "known divergence (unsafe array folding): constant-folds array holes/length while the case pollutes Array.prototype with index properties"
+    },
+    {
+      "file": "compress/properties.js",
+      "name": "array_hole",
+      "reason": "known divergence (unsafe array folding): constant-folds array holes/length while the case pollutes Array.prototype with index properties"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "ascii_only",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "ascii_only_ecma",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "ascii_only_templates",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "ascii_only_templates_ecma",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "unicode",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "unicode_ecma",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "unicode_templates",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/templates.js",
+      "name": "unicode_templates_ecma",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/unicode.js",
+      "name": "issue_2242_3",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/unicode.js",
+      "name": "issue_2242_4",
+      "reason": "known divergence (codegen): a lone surrogate in a string/template is emitted lossily (U+FFFD) instead of as a \\uXXXX escape; not a compressor-semantics issue"
+    },
+    {
+      "file": "compress/classes.js",
+      "name": "keep_fnames",
+      "reason": "expected pipeline behavior: standard minify drops unreferenced named function/class expression names, observed via `.name` (the case needs the keep_fnames/keep_classnames option we intentionally ignore, like esbuild)"
+    },
+    {
+      "file": "compress/functions.js",
+      "name": "functions_keep_fnames",
+      "reason": "expected pipeline behavior: standard minify drops unreferenced named function/class expression names, observed via `.name` (the case needs the keep_fnames/keep_classnames option we intentionally ignore, like esbuild)"
+    },
+    {
+      "file": "compress/awaits.js",
+      "name": "issue_4974",
+      "reason": "not a useful differential case: runaway async self-recursion (`42 in f()`) overflows the promise machinery, emitting V8-level 'Exception in PromiseRejectCallback' stderr that JavaScript cannot trap; identical before/after minify anyway"
+    }
+  ]
+}


### PR DESCRIPTION
Third oracle, stacked on the bundle diff PR (shares only the `runtime-minify` subcommand): run UglifyJS's `test/compress` corpus — thousands of tiny programs with observable runtime output — as a differential check against oxc main. esbuild has run this exact corpus in CI for years; swc vendors it.

## How it works

`scripts/uglify-corpus-test.mjs <clone>`:

1. Parse the corpus's case DSL (token-aware scanner, provably complete: every `expect_stdout`-bearing case in the pinned corpus is accounted for — 3,568/3,568) and extract each runnable case to a scratch tree.
2. Minify the whole tree with **one** `runtime-minify` pass (standard full pipeline; per-case uglify options deliberately ignored, as esbuild does).
3. Execute original and minified per case in fresh `vm` contexts (ported uglify sandbox semantics: captured stdout, `Function#toString` normalization, 5s timeout) and byte-diff.

**Purely differential**: expected output is always derived by executing the original in-run — the corpus's own `expect_stdout` strings are never trusted, so corpus age can't cause false reds. Originals run twice as a determinism gate (nondeterministic case → warning + auto-skip). Failures are pre-minimized repros by construction.

Current numbers at the pinned corpus: **4,263 cases → 3,331 compared, 107 skipped (each with a documented reason in [`uglify-corpus.json`](./uglify-corpus.json)), 825 structurally excluded** (no runnable output / need a module loader for lowered helper imports / node-version-gated). Runs in about a minute on system node with no installs.

## It found 14 real oxc bug classes on its first run

Vetting surfaced 14 distinct deterministic bug classes across 54 cases (several reproduced in plain node), now in the skip list as documented defects pending upstream issues/fixes — highlights: `delete (0, NaN)` folded to `delete NaN` (flips `true`→`false`), strict directive lost when eliminating a strict IIFE (`this` becomes globalThis), `for (a => { a in a; }; ;)` rejected by the parser (no-`in` leaking into an arrow body), BigInt `**=` miscompiled into a throwing unary `+`, async-generator `try/finally` skipping the `finally`, lone-surrogate strings emitted lossily as U+FFFD, `with`-scope-shadowed globals substituted (`Infinity` → `1/0`), a mangler TDZ collision, and six more (arguments linkage, Annex-B hoisting, destructuring side-effect order, optional-chain `this`, unary-`+` timing, DCE dropping a throwing call). Upstream filing to follow separately; each skip entry references the local evidence trail.

## Notes

- The 121 module-loader exclusions (~3.6%) are lowered-helper `require()`s that can't resolve in the builtins-only vm — an acknowledged coverage gap, deliberately traded for a zero-install CI row.
- `record.needs` gains the job; the one-line union with the repo-suites PR's `needs` resolves trivially at merge.
