### PR TITLE
ci: cancel superseded main runs on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,13 @@ on:
         default: 'main'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  # Pushes to main share one group (`github.ref`) and cancel the superseded
+  # in-progress run, so back-to-back merges don't stack full CI runs. PR runs
+  # keep their per-PR group; schedule/dispatch runs keep the per-sha group
+  # with no cancellation (concurrent oxc-PR dispatches must queue, not cancel
+  # each other).
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' || github.event_name == 'push' }}
 
 jobs:
   status:


### PR DESCRIPTION
## Summary

- Pushes to main currently group CI by `github.sha`, so each merge gets its own concurrency group and nothing is ever cancelled — three back-to-back merges ran three full CI passes, two of them on already-outdated commits.
- Group push runs by `github.ref` with `cancel-in-progress`, so a new merge cancels the superseded in-progress run.
- PR runs keep the per-PR cancelling group. Schedule and `workflow_dispatch` runs keep the per-sha queueing group: concurrent oxc-PR dispatches must queue rather than cancel each other, and a scheduled run cancelled by a push only skips the green-marker record, which the record job already treats as "one extra run later".
