### PR TITLE
ci: pin prettier version

### DIFF
--- a/generate.mjs
+++ b/generate.mjs
@@ -143,6 +143,10 @@ const testEntries = data.map((name) => ({
 
 packageJson.devDependencies = {};
 data.map((name) => {
+  // Packages in `dependencies` are version-managed explicitly (e.g. prettier, the formatter oracle);
+  // don't shadow them with a corpus `latest` entry.
+  if (name in packageJson.dependencies) return;
+  
   packageJson.devDependencies[name] = "latest";
 });
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/standalone": "latest",
     "@oxc-project/runtime": "latest",
     "npm-high-impact": "1.12.0",
+    "prettier": "3.9.5",
     "tsx": "latest",
     "vitest": "latest"
   },
@@ -2342,7 +2343,6 @@
     "prebuild-install": "latest",
     "prelude-ls": "latest",
     "prepend-http": "latest",
-    "prettier": "latest",
     "prettier-linter-helpers": "latest",
     "pretty-bytes": "latest",
     "pretty-error": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       npm-high-impact:
         specifier: 1.12.0
         version: 1.12.0
+      prettier:
+        specifier: 3.9.5
+        version: 3.9.5
       tsx:
         specifier: latest
         version: 4.22.3
@@ -3923,7 +3926,7 @@ importers:
         version: 18.0.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3)
       eslint-plugin-prettier:
         specifier: latest
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.9.5)
       eslint-plugin-promise:
         specifier: latest
         version: 7.3.0(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
@@ -3938,7 +3941,7 @@ importers:
         version: 0.5.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-storybook:
         specifier: latest
-        version: 10.4.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(storybook@10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 10.4.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(storybook@10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.9.5)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-testing-library:
         specifier: latest
         version: 7.16.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
@@ -6996,9 +6999,6 @@ importers:
       prepend-http:
         specifier: latest
         version: 4.0.0
-      prettier:
-        specifier: latest
-        version: 3.8.3
       prettier-linter-helpers:
         specifier: latest
         version: 1.0.1
@@ -28338,8 +28338,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.5:
+    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -29002,6 +29002,10 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  recast@0.23.12:
+    resolution: {integrity: sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==}
+    engines: {node: '>= 4'}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -29602,6 +29606,11 @@ packages:
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -32839,6 +32848,18 @@ packages:
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -47600,10 +47621,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.9.5):
     dependencies:
       eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      prettier: 3.8.3
+      prettier: 3.9.5
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
@@ -47656,11 +47677,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.4.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(storybook@10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@6.0.3):
+  eslint-plugin-storybook@10.4.1(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(storybook@10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.9.5)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.59.2(eslint@10.4.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint: 10.4.0(jiti@2.7.0)(supports-color@10.2.2)
-      storybook: 10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      storybook: 10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.9.5)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -55212,7 +55233,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.8.3: {}
+  prettier@3.9.5: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -55924,6 +55945,14 @@ snapshots:
   real-require@1.0.0: {}
 
   recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  recast@0.23.12:
     dependencies:
       ast-types: 0.16.1
       esprima: 4.0.1
@@ -56665,6 +56694,8 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.1: {}
+
+  semver@7.8.5: {}
 
   send@0.19.0(supports-color@10.2.2):
     dependencies:
@@ -57427,7 +57458,7 @@ snapshots:
 
   stoppable@1.1.0: {}
 
-  storybook@10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
+  storybook@10.0.2(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(prettier@3.9.5)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -57437,11 +57468,11 @@ snapshots:
       '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@24.10.0)(typescript@6.0.3))(vite@8.0.14(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/spy': 3.2.4
       esbuild: 0.25.12
-      recast: 0.23.11
-      semver: 7.8.1
-      ws: 8.21.0
+      recast: 0.23.12
+      semver: 7.8.5
+      ws: 8.21.1
     optionalDependencies:
-      prettier: 3.8.3
+      prettier: 3.9.5
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -60224,6 +60255,8 @@ snapshots:
   ws@8.20.1: {}
 
   ws@8.21.0: {}
+
+  ws@8.21.1: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
Looking at the CI results, it seemed like an older version of Prettier was being used.

Even after updating the lock file, Renovate would overwrite it to the `latest` version, so I pinned it to the version bundled with oxfmt.
