### PR TITLE
ci: find the status comment instead of taking a comment-id input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,11 @@ on:
   workflow_dispatch:
     inputs:
       issue-number:
-        required: false
-        type: string
-      comment-id:
+        description: 'oxc PR/issue number to post the status comment to'
         required: false
         type: string
       ref:
+        description: 'oxc ref to test (branch, sha, or refs/pull/<n>/head)'
         required: false
         type: string
         default: 'main'
@@ -38,7 +37,7 @@ concurrency:
 
 jobs:
   status:
-    if: ${{ inputs.issue-number && inputs.comment-id }}
+    if: ${{ inputs.issue-number }}
     name: Status
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -56,14 +55,41 @@ jobs:
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          COMMENT_ID: ${{ inputs.comment-id }}
+          ISSUE_NUMBER: ${{ inputs.issue-number }}
           OXC_REF: ${{ inputs.ref || 'main' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const commentId = Number(process.env.COMMENT_ID);
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
             const oxcRef = process.env.OXC_REF || 'main';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // One status comment per PR: reuse the trigger comment left by
+            // oxc's monitor-oxc workflow or a previous run's status comment
+            // (same matching logic as the oxc side); create one only when
+            // neither exists, e.g. on a manual dispatch.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: 'oxc-project',
+              repo: 'oxc',
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = comments.findLast((c) =>
+              c.user.login === 'oxc-guard[bot]' &&
+              c.body &&
+              (c.body.startsWith('Triggering Monitor Oxc') || c.body.startsWith('## [Monitor Oxc]'))
+            );
+            let commentId = existing?.id;
+            if (!commentId) {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: 'oxc-project',
+                repo: 'oxc',
+                issue_number: issueNumber,
+                body: `## [Monitor Oxc](${runUrl})\n\n:hourglass: Waiting for jobs to start…`,
+              });
+              commentId = created.id;
+            }
+
             let commitUrl = `${context.serverUrl}/oxc-project/oxc/tree/${oxcRef}`;
             let shortSha = oxcRef;
             try {


### PR DESCRIPTION
Posting a CI status comment to an oxc PR requires the caller to pass a `comment-id`: the status job can only update an existing comment, never find or create one. The oxc-side trigger therefore has to find-or-create the comment itself before dispatching, and a manual `workflow_dispatch` run needs the same dance by hand — create a placeholder comment on the PR, capture its id, and pass it along, or no status is reported at all.

The status job now owns the lookup. It scans the PR's comments for the most recent one authored by `oxc-guard[bot]` whose body starts with `Triggering Monitor Oxc` or `## [Monitor Oxc]` — the same matching logic oxc's trigger already uses — and updates that comment, creating a fresh one only when none exists. Each PR keeps a single status comment across repeated runs, the `comment-id` input is gone, and a manual run is one step:

```
gh workflow run ci.yml -f issue-number=<N> -f ref=refs/pull/<N>/head
```

Merge order matters: oxc's `monitor-oxc.yml` still passes `comment-id` in its dispatch payload, and dispatching with an input the workflow no longer defines is rejected with a 422. The oxc-side change (stop passing `comment-id`; its prepare-comment step can be dropped entirely) must land first. The old workflow receiving no `comment-id` merely skips the status job, so that transition gap is harmless.

Verified that the workflow YAML parses and the embedded github-script block is syntactically valid.
