### PR TITLE
fix(formatter): follow oxc_formatter::format signature change

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -38,7 +38,6 @@ impl Case for FormatterRunner {
             source_text,
             *source_type,
             JsFormatOptions::default(),
-            None,
         ) {
             Ok(formatted) => formatted.print().unwrap().into_code(),
             Err(error) => {
@@ -62,7 +61,6 @@ impl Case for FormatterRunner {
             &source_text2,
             *source_type,
             JsFormatOptions::default(),
-            None,
         ) {
             Ok(formatted) => formatted.print().unwrap().into_code(),
             Err(error) => {

--- a/src/formatter_dcr.rs
+++ b/src/formatter_dcr.rs
@@ -35,7 +35,6 @@ impl Case for FormatterDCRRunner {
             source_text,
             *source_type,
             JsFormatOptions::default(),
-            None,
         ) {
             Ok(formatted) => formatted.print().unwrap().into_code(),
             // Skip files that fail to parse, already reported in `FormatterRunner`


### PR DESCRIPTION
The Build job fails to compile since oxc-project/oxc#25388 moved external callbacks into `SessionServices` on `FormatSession`, removing the `external_callbacks` parameter from `format()` ([failing run](https://github.com/oxc-project/monitor-oxc/actions/runs/31359248351/job/93364683846)). Drops the trailing `None` at the three call sites. Verified with `cargo check` against current oxc main.

The Test262 job is red for an unrelated reason — snapshot drift on the oxc side from flaky timeouts baked in by oxc-project/oxc#25261 — and stays red until oxc-project/oxc#25471 merges.

This PR was assisted by Claude.