### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ globset = "0.4"
 # Disabling debug info reduces stack usage
 debug = false
 
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 strip = false # "symbols" # Set to `false` for debug information
 debug = true # Set to `true` for debug information


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.