### PR TITLE
fix: scope annotation preservation to runtime minification

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -27,6 +27,7 @@ pub struct Driver {
     pub dce: bool,
     pub mangle: bool,
     pub remove_whitespace: bool,
+    pub preserve_annotations: bool,
     // states
     pub printed: String,
     pub path: PathBuf,
@@ -92,7 +93,10 @@ impl CompilerInterface for Driver {
         Some(CodegenOptions {
             minify: self.remove_whitespace,
             comments: if self.compress.is_some() {
-                CommentOptions { annotation: true, ..CommentOptions::disabled() }
+                CommentOptions {
+                    annotation: self.preserve_annotations,
+                    ..CommentOptions::disabled()
+                }
             } else {
                 CommentOptions::default()
             },
@@ -151,20 +155,33 @@ mod tests {
 
     use super::Driver;
 
-    #[test]
-    fn compression_preserves_annotation_comments_only() {
+    fn compress(preserve_annotations: bool) -> String {
         let mut driver = Driver {
             compress: Some(CompressOptions::default()),
             remove_whitespace: true,
+            preserve_annotations,
             ..Driver::default()
         };
-        let output = driver
+        driver
             .run(
                 Path::new("fixture.js"),
                 "export const value = /* @__PURE__ */ Symbol('value'); /* ordinary */",
                 SourceType::default(),
             )
-            .unwrap();
+            .unwrap()
+    }
+
+    #[test]
+    fn compression_strips_comments_by_default() {
+        let output = compress(false);
+
+        assert!(!output.contains("@__PURE__"));
+        assert!(!output.contains("ordinary"));
+    }
+
+    #[test]
+    fn compression_can_preserve_annotation_comments_only() {
+        let output = compress(true);
 
         assert!(output.contains("@__PURE__"));
         assert!(!output.contains("ordinary"));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -108,6 +108,7 @@ fn minify_driver() -> Driver {
         compress: Some(CompressOptions::default()),
         mangle: true,
         remove_whitespace: true,
+        preserve_annotations: true,
         ..Driver::default()
     }
 }


### PR DESCRIPTION
PR #217 enabled annotation comments for every compressor use, so the general compressor oracle now reports 69 output differences consisting only of coverage directives such as `/* istanbul ignore if */`.

Make annotation preservation opt-in on the shared driver and enable it only for runtime-minify. The compressor oracle continues producing comment-free output, while runtime-minified packages retain the annotations needed by downstream tree-shaking tools.

Covered by regression tests for both driver modes. Verified with `cargo test --lib`, repository-wide Clippy, and the pinned Zod runtime suite: 180 files and 2,242 tests pass after in-place minification.

Follow-up to #217 and [the failing compressor job](https://github.com/oxc-project/monitor-oxc/actions/runs/33173216981/job/98855640746).

This PR was prepared with AI assistance.
